### PR TITLE
chore(main): release

### DIFF
--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitEnums.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitEnums.g.cs
@@ -11,7 +11,7 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Ads.AdManager.V1 {
 
-  /// <summary>Holder for reflection information generated from google/ads/admanager/v1/ad_unit_enums.proto</summary>
+  /// <summary>Holder for [test change] reflection information generated from google/ads/admanager/v1/ad_unit_enums.proto</summary>
   public static partial class AdUnitEnumsReflection {
 
     #region Descriptor

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitEnums.g.cs
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/AdUnitEnums.g.cs
@@ -11,7 +11,7 @@ using pbr = global::Google.Protobuf.Reflection;
 using scg = global::System.Collections.Generic;
 namespace Google.Ads.AdManager.V1 {
 
-  /// <summary>Holder for [test change] reflection information generated from google/ads/admanager/v1/ad_unit_enums.proto</summary>
+  /// <summary>Holder for [test change 2] reflection information generated from google/ads/admanager/v1/ad_unit_enums.proto</summary>
   public static partial class AdUnitEnumsReflection {
 
     #region Descriptor

--- a/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.csproj
+++ b/apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta01</Version>
+    <Version>1.0.0-beta02</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Ad Manager API, which allows you to manage your Ad Manager inventory, run reports and more.</Description>

--- a/apis/Google.Ads.AdManager.V1/docs/history.md
+++ b/apis/Google.Ads.AdManager.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta02, released 2025-03-21
+
+### New features
+
+- Update AdUnitEnums.g.cs
+
 ## Version 1.0.0-beta01, released 2024-10-03
 
 Initial release.

--- a/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
+++ b/apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.23.0</Version>
+    <Version>3.24.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Vertex AI API (v1), which allows you to train high-quality custom machine learning models with minimal machine learning expertise and effort.</Description>

--- a/apis/Google.Cloud.AIPlatform.V1/docs/history.md
+++ b/apis/Google.Cloud.AIPlatform.V1/docs/history.md
@@ -1,5 +1,16 @@
 # Version history
 
+## Version 3.24.0, released 2025-03-21
+
+### New features
+
+- Add env variables and agent framework to ReasoningEngineSpec
+
+### Documentation improvements
+
+- Update comment for `package_spec` from required to optional in `ReasoningEngineSpec`.
+- Add `deployment_spec` and `agent_framework` field to `ReasoningEngineSpec`.
+
 ## Version 3.23.0, released 2025-03-17
 
 ### New features

--- a/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta09</Version>
+    <Version>1.0.0-beta10</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the AlloyDB API (v1beta). AlloyDB for PostgreSQL is an open source-compatible database service that provides a powerful option for migrating, modernizing, or building commercial-grade applications.</Description>

--- a/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
+++ b/apis/Google.Cloud.AlloyDb.V1Beta/docs/history.md
@@ -1,5 +1,23 @@
 # Version history
 
+## Version 1.0.0-beta10, released 2025-03-21
+
+### New features
+
+- A new method `ExportCluster` is added to service `AlloyDBAdmin`
+- A new message `GcsDestination` is added
+- A new message `ExportClusterRequest` is added
+- A new message `ExportClusterResponse` is added
+
+### Documentation improvements
+
+- A comment for field `zone_id` in message `.google.cloud.alloydb.v1beta.Instance` is changed
+- A comment for field `id` in message `.google.cloud.alloydb.v1beta.Instance` is changed
+- A comment for field `ip` in message `.google.cloud.alloydb.v1beta.Instance` is changed
+- A comment for field `state` in message `.google.cloud.alloydb.v1beta.Instance` is changed
+- A comment for field `database_flags` in message `.google.cloud.alloydb.v1beta.Instance` is changed
+- A comment for field `requested_cancellation` in message `.google.cloud.alloydb.v1beta.OperationMetadata` is changed
+
 ## Version 1.0.0-beta09, released 2024-11-18
 
 ### Bug fixes

--- a/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
+++ b/apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>3.6.0</Version>
+    <Version>3.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Compute Engine API.</Description>

--- a/apis/Google.Cloud.Compute.V1/docs/history.md
+++ b/apis/Google.Cloud.Compute.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 3.7.0, released 2025-03-21
+
+### New features
+
+- Update Compute Engine API to revision 20250302 (#995)
+
 ## Version 3.6.0, released 2025-03-17
 
 ### New features

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.0.0-beta23</Version>
+    <Version>2.0.0-beta24</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Document AI API (v1beta3), which is a service to parse structured information from unstructured or semi-structured documents using state-of-the-art Google AI such as natural language, computer vision, translation, and AutoML.</Description>

--- a/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
+++ b/apis/Google.Cloud.DocumentAI.V1Beta3/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 2.0.0-beta24, released 2025-03-21
+
+### New features
+
+- Added config options to enable LLM layout parsing
+
+### Documentation improvements
+
+- mark fields as unused
+
 ## Version 2.0.0-beta23, released 2024-10-21
 
 ### New features

--- a/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.csproj
+++ b/apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta04</Version>
+    <Version>1.0.0-beta05</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Managed Service for Apache Kafka API, which lets you ingest Kafka streams directly into Google Cloud.</Description>

--- a/apis/Google.Cloud.ManagedKafka.V1/docs/history.md
+++ b/apis/Google.Cloud.ManagedKafka.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta05, released 2025-03-21
+
+### New features
+
+- add Managed Kafka Connect API
+
 ## Version 1.0.0-beta04, released 2025-03-17
 
 ### Bug fixes

--- a/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
+++ b/apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.5.0</Version>
+    <Version>2.6.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Workflows API v1.</Description>

--- a/apis/Google.Cloud.Workflows.V1/docs/history.md
+++ b/apis/Google.Cloud.Workflows.V1/docs/history.md
@@ -1,5 +1,19 @@
 # Version history
 
+## Version 2.6.0, released 2025-03-21
+
+### New features
+
+- add ListWorkflowRevisions method
+- add ExecutionHistoryLevel to Workflow
+- add crypto key config to Workflow
+- add tags to Workflow
+- add ExecutionHistoryLevel enum
+
+### Documentation improvements
+
+- update Workflow some standard field docs
+
 ## Version 2.5.0, released 2024-05-14
 
 ### New features

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.csproj
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-beta03</Version>
+    <Version>1.0.0-beta04</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Merchant Products API (v1beta) which allows you to programmatically manage your Merchant Center accounts.</Description>

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/PackageApiMetadata.g.cs
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta/PackageApiMetadata.g.cs
@@ -21,7 +21,7 @@ using scg = System.Collections.Generic;
 
 namespace Google.Shopping.Merchant.Products.V1Beta
 {
-    /// <summary>Static class to provide common access to package-wide API metadata.</summary>
+    /// <summary>Static class test to provide common access to package-wide API metadata.</summary>
     internal static class PackageApiMetadata
     {
         /// <summary>The <see cref="gaxgrpc::ApiMetadata"/> for services in this package.</summary>

--- a/apis/Google.Shopping.Merchant.Products.V1Beta/docs/history.md
+++ b/apis/Google.Shopping.Merchant.Products.V1Beta/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.0.0-beta04, released 2025-03-21
+
+### New features
+
+- Update PackageApiMetadata.g.cs
+
 ## Version 1.0.0-beta03, released 2025-03-17
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -3261,7 +3261,7 @@
     },
     {
       "id": "Google.Cloud.ManagedKafka.V1",
-      "version": "1.0.0-beta04",
+      "version": "1.0.0-beta05",
       "type": "grpc",
       "productName": "Managed Service for Apache Kafka API",
       "productUrl": "https://cloud.google.com/managed-kafka",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2,7 +2,7 @@
   "apis": [
     {
       "id": "Google.Ads.AdManager.V1",
-      "version": "1.0.0-beta01",
+      "version": "1.0.0-beta02",
       "type": "grpc",
       "productName": "Google Ad Manager",
       "productUrl": "https://developers.google.com/ad-manager/api/beta",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2310,7 +2310,7 @@
     },
     {
       "id": "Google.Cloud.DocumentAI.V1Beta3",
-      "version": "2.0.0-beta23",
+      "version": "2.0.0-beta24",
       "type": "grpc",
       "productName": "Cloud Document AI",
       "productUrl": "https://cloud.google.com/solutions/document-ai",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1566,7 +1566,7 @@
     },
     {
       "id": "Google.Cloud.Compute.V1",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "type": "regapic",
       "productName": "Compute Engine",
       "productUrl": "https://cloud.google.com/compute",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -397,7 +397,7 @@
     },
     {
       "id": "Google.Cloud.AIPlatform.V1",
-      "version": "3.23.0",
+      "version": "3.24.0",
       "type": "grpc",
       "productName": "Vertex AI",
       "productUrl": "https://cloud.google.com/vertex-ai/docs",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -326,7 +326,7 @@
     },
     {
       "id": "Google.Cloud.AlloyDb.V1Beta",
-      "version": "1.0.0-beta09",
+      "version": "1.0.0-beta10",
       "type": "grpc",
       "productName": "AlloyDB",
       "productUrl": "https://cloud.google.com/alloydb/docs",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -6352,7 +6352,7 @@
     },
     {
       "id": "Google.Shopping.Merchant.Products.V1Beta",
-      "version": "1.0.0-beta03",
+      "version": "1.0.0-beta04",
       "type": "grpc",
       "productName": "Merchant",
       "productUrl": "https://developers.google.com/merchant/api",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -5872,7 +5872,7 @@
     },
     {
       "id": "Google.Cloud.Workflows.V1",
-      "version": "2.5.0",
+      "version": "2.6.0",
       "commonResourcesConfig": "tweaks/Google.Cloud.Workflows.Common.V1/CommonResourcesConfig.json",
       "type": "grpc",
       "productName": "Workflows",

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -668,7 +668,7 @@
         },
         {
             "id": "google/cloud/managedkafka/v1",
-            "lastGeneratedCommit": "8f7e301d346ba792a9bd282f8d62db7fad87cb8a",
+            "lastGeneratedCommit": "fba13dc09aa7a6619359550c4b13992f63b0cdc9",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
         },
         {
@@ -3379,7 +3379,7 @@
         },
         {
             "id": "Google.Cloud.ManagedKafka.V1",
-            "currentVersion": "1.0.0-beta04",
+            "currentVersion": "1.0.0-beta05",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-03-17T18:54:24Z",
             "apis": [

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1308,7 +1308,7 @@
         },
         {
             "id": "google/shopping/merchant/products/v1beta",
-            "lastGeneratedCommit": "bc7f715d7f58afe381fbc244a8bcde7f0afa11ed",
+            "lastGeneratedCommit": "31d5d2b6125546b577f7a7adf1664a264747d64e",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
         },
         {
@@ -5275,7 +5275,7 @@
         },
         {
             "id": "Google.Shopping.Merchant.Products.V1Beta",
-            "currentVersion": "1.0.0-beta03",
+            "currentVersion": "1.0.0-beta04",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-03-17T18:40:29Z",
             "apis": [

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -98,7 +98,7 @@
         },
         {
             "id": "google/cloud/aiplatform/v1",
-            "lastGeneratedCommit": "2c2a335e10b6b35b02b28dd1004ebdc94790d14d",
+            "lastGeneratedCommit": "65eb876885c7d19a7af9758f9588b06a93ac1385",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
         },
         {
@@ -1630,7 +1630,7 @@
         },
         {
             "id": "Google.Cloud.AIPlatform.V1",
-            "currentVersion": "3.23.0",
+            "currentVersion": "3.24.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-03-17T18:52:22Z",
             "apis": [

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1203,7 +1203,7 @@
         },
         {
             "id": "google/cloud/workflows/v1",
-            "lastGeneratedCommit": "d7db9c6f0c5a52efda18e8cc3e3e8e6a67ee3b5c",
+            "lastGeneratedCommit": "f5a0bda387fdb74582ab9f7fff13163f623a38eb",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
         },
         {
@@ -4945,7 +4945,7 @@
         },
         {
             "id": "Google.Cloud.Workflows.V1",
-            "currentVersion": "2.5.0",
+            "currentVersion": "2.6.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-05-14T15:40:22Z",
             "apis": [

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -483,7 +483,7 @@
         },
         {
             "id": "google/cloud/documentai/v1beta3",
-            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "lastGeneratedCommit": "602d65c092a5310d93b80e965fe9539b6ae679b3",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
         },
         {
@@ -2812,7 +2812,7 @@
         },
         {
             "id": "Google.Cloud.DocumentAI.V1Beta3",
-            "currentVersion": "2.0.0-beta23",
+            "currentVersion": "2.0.0-beta24",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-10-22T17:56:27Z",
             "apis": [

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -3,7 +3,7 @@
     "apiGenerationStates": [
         {
             "id": "google/ads/admanager/v1",
-            "lastGeneratedCommit": "0b8fa5230f3f04e3ea8aa8343f21b505bb2b7a10",
+            "lastGeneratedCommit": "cf43b8894f294ac7b77fa5b87dc8e82b6d532f31",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
         },
         {
@@ -1345,7 +1345,7 @@
     "libraryReleaseStates": [
         {
             "id": "Google.Ads.AdManager.V1",
-            "currentVersion": "1.0.0-beta01",
+            "currentVersion": "1.0.0-beta02",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-10-03T15:36:23Z",
             "apis": [
@@ -2113,7 +2113,6 @@
             "currentVersion": "3.11.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-02-03T17:58:23Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2"
             ]
@@ -2153,7 +2152,6 @@
             "currentVersion": "3.2.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-03-26T19:14:17Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2"
             ]
@@ -2703,7 +2701,6 @@
             "currentVersion": "3.2.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-03-27T17:16:22Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common"
             ]
@@ -3313,7 +3310,6 @@
             "currentVersion": "4.4.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-09-26T08:16:29Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net"
             ]
@@ -3323,7 +3319,6 @@
             "currentVersion": "1.4.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-03-03T18:14:27Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console"
             ]
@@ -3333,7 +3328,6 @@
             "currentVersion": "5.2.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-09-26T08:16:33Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog"
             ]
@@ -4513,7 +4507,6 @@
             "currentVersion": "4.11.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-03-10T18:24:32Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1"
             ]
@@ -4733,7 +4726,6 @@
             "currentVersion": "3.4.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-03-26T19:47:02Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2"
             ]
@@ -4908,7 +4900,6 @@
             "currentVersion": "2.4.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-03-26T19:52:25Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1"
             ]
@@ -4918,7 +4909,6 @@
             "currentVersion": "2.0.0-beta04",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-03-26T19:52:48Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta"
             ]
@@ -5405,7 +5395,6 @@
             "currentVersion": "5.2.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-03-05T19:58:15Z",
-            "apis": [],
             "sourcePaths": [
                 "apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3",
                 "apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common"
@@ -5448,7 +5437,7 @@
             ]
         }
     ],
-    "common_library_source_paths": [
+    "commonLibrarySourcePaths": [
         "Directory.Packages.props"
     ]
 }

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1,1295 +1,5454 @@
 {
-  "imageTag": "latest",
-  "apiGenerationStates": [
-    {
-      "id": "google/ads/admanager/v1",
-      "lastGeneratedCommit": "0b8fa5230f3f04e3ea8aa8343f21b505bb2b7a10",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/analytics/admin/v1alpha",
-      "lastGeneratedCommit": "f20edbd0900fad2b5cb593d01589938db263ac42",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/analytics/admin/v1beta",
-      "lastGeneratedCommit": "89a0f8e22df3d09eb1a283a32cb3772ad2553fce",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/analytics/data/v1beta",
-      "lastGeneratedCommit": "6fb68312dc1372cbc497f0e5294c94945879736c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/apps/card/v1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/chat/v1",
-      "lastGeneratedCommit": "60bab918c62a0fbcab7f05318b999751d40019bb",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/apps/events/subscriptions/v1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/apps/meet/v2",
-      "lastGeneratedCommit": "6dedc0542a0986dcc7b977b20399cdcbb1bdb4bb",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/apps/meet/v2beta",
-      "lastGeneratedCommit": "137b7e602323dc84e7d8bba77a65e1c0b8bbf6d9",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/apps/script/type",
-      "lastGeneratedCommit": "d196cb2d69e542020101d8a30f1e33497835a4f1",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/area120/tables/v1alpha1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/accessapproval/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/advisorynotifications/v1",
-      "lastGeneratedCommit": "51de26cce4b5ed4e7be991bedab8bcb789a8d1ae",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/alloydb/v1",
-      "lastGeneratedCommit": "1f3eb168e3fc43799e45e6e9df36cb3298e1d605",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/alloydb/v1alpha",
-      "lastGeneratedCommit": "1f3eb168e3fc43799e45e6e9df36cb3298e1d605",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/alloydb/v1beta",
-      "lastGeneratedCommit": "1f3eb168e3fc43799e45e6e9df36cb3298e1d605",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/apigateway/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/aiplatform/v1beta1",
-      "lastGeneratedCommit": "901fc8ee4257d5d7b0d53ba3494fab53bf1a2a67",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/aiplatform/v1",
-      "lastGeneratedCommit": "9a61deddf9bdccd92bc6701f26334f15857e853b",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/apihub/v1",
-      "lastGeneratedCommit": "8c6de209d316e7a33fcd28e743ae893c83b17eed",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/api/apikeys/v2",
-      "lastGeneratedCommit": "51de26cce4b5ed4e7be991bedab8bcb789a8d1ae",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/apigeeconnect/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/apigeeregistry/v1",
-      "lastGeneratedCommit": "cead73336b652505e12689826d9ad037eb8852b0",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/appengine/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/apphub/v1",
-      "lastGeneratedCommit": "54d659d0ae74f39e92755948b821a1495b3cb3c8",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/artifactregistry/v1",
-      "lastGeneratedCommit": "5dc10a42f836b42b091088408ab3e17172ce7359",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/artifactregistry/v1beta2",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/asset/v1",
-      "lastGeneratedCommit": "651af4b02f16b5c04c7c4f721d3533ca6869e7c8",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/assuredworkloads/v1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/assuredworkloads/v1beta1",
-      "lastGeneratedCommit": "620613892975f238bff26bb11658c07f564916bf",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/audit",
-      "lastGeneratedCommit": "9c586e8f14bcd6dfe47c35a5dcbeac446e634f73",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/automl/v1",
-      "lastGeneratedCommit": "05347e0a68ac16ec35146249d598fcdc6dd8c0c5",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/backupdr/v1",
-      "lastGeneratedCommit": "8cd87061e43b6adf3f7d0b1d40d0f6192cc2ca74",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/baremetalsolution/v2",
-      "lastGeneratedCommit": "51de26cce4b5ed4e7be991bedab8bcb789a8d1ae",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/batch/v1",
-      "lastGeneratedCommit": "f7314d1e02e7651b33985c65c2d268de7fbacc1e",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/batch/v1alpha",
-      "lastGeneratedCommit": "baa225c2e09886cf0fb972ca286818d0e1e02675",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/beyondcorp/appconnections/v1",
-      "lastGeneratedCommit": "3d160b66bda7e37b90d6509b7ad2ce668e9350f1",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/beyondcorp/appconnectors/v1",
-      "lastGeneratedCommit": "3d160b66bda7e37b90d6509b7ad2ce668e9350f1",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/beyondcorp/appgateways/v1",
-      "lastGeneratedCommit": "3d160b66bda7e37b90d6509b7ad2ce668e9350f1",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/beyondcorp/clientgateways/v1",
-      "lastGeneratedCommit": "3d160b66bda7e37b90d6509b7ad2ce668e9350f1",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/analyticshub/v1",
-      "lastGeneratedCommit": "c23223d273469bc9c0f296856b47d22fa1dfe3d9",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/connection/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/dataexchange/v1beta1",
-      "lastGeneratedCommit": "6fb68312dc1372cbc497f0e5294c94945879736c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/datapolicies/v1",
-      "lastGeneratedCommit": "668cf05677fbb1bb3311bec0c3453ab782f62e91",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/datapolicies/v1beta1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/datatransfer/v1",
-      "lastGeneratedCommit": "463b5a6b06e20504fb44bfedff59ba05b42bf0b2",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/migration/v2",
-      "lastGeneratedCommit": "ec69fcc8024d39302d58111962b15335c289a883",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/reservation/v1",
-      "lastGeneratedCommit": "4743cf9ecab30cb113a7809aacbdbbba376f79f6",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/bigquery/storage/v1",
-      "lastGeneratedCommit": "b49a983820806fc0d903370c0e75129fe7ae3c7b",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/bigtable/admin/v2",
-      "lastGeneratedCommit": "07737e56be021ca2d11a24fb759ff3de79d83fa0",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/bigtable/v2",
-      "lastGeneratedCommit": "ab2ad69473e17b813f5555a44b89691f67b66297",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/billing/budgets/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/billing/budgets/v1beta1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/billing/v1",
-      "lastGeneratedCommit": "e5a39127db2d2339f7265be7175a3734385bd672",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/binaryauthorization/v1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/binaryauthorization/v1beta1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/certificatemanager/v1",
-      "lastGeneratedCommit": "b5cd5b2517482f1f3d09b89b901accd4f15cb265",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/channel/v1",
-      "lastGeneratedCommit": "b6a27d13a2f0223051ef720e4e9d0d52323560e6",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/cloudbuild/v1",
-      "lastGeneratedCommit": "fd5b486367b0cf4ecf616ea2677dfa14f83a71c6",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/cloudbuild/v2",
-      "lastGeneratedCommit": "21d5d3def00d8e7dbba6037af0774161fabe56c9",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/cloudcontrolspartner/v1",
-      "lastGeneratedCommit": "9ebde5402abfe4014e63f3a9bb45c206a2a66f32",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/cloudcontrolspartner/v1beta",
-      "lastGeneratedCommit": "4d8214803feb680a2dfa8ca4437b7ddfe64d146d",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/clouddms/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/api/cloudquotas/v1",
-      "lastGeneratedCommit": "453365efd71565dbecb05bbdc48513a7b3236d21",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/commerce/consumer/procurement/v1",
-      "lastGeneratedCommit": "1f8352cf46df74d7db6fd544181655c590689b8c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/common",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/compute/v1",
-      "lastGeneratedCommit": "2e899eed4464394e6298e3c4cfd4a40d83a6b1ba",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/confidentialcomputing/v1",
-      "lastGeneratedCommit": "5afbbeb4cc5e89393d279a60bc36d73982229f52",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/confidentialcomputing/v1alpha1",
-      "lastGeneratedCommit": "5afbbeb4cc5e89393d279a60bc36d73982229f52",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/config/v1",
-      "lastGeneratedCommit": "29aea4190aba664659908ff5e381c830e4752502",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/connectors/v1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/contactcenterinsights/v1",
-      "lastGeneratedCommit": "5546362a78d82f8307eb1af4b2ac178a90cd9271",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/container/v1",
-      "lastGeneratedCommit": "8798ceff3f6fbcdce3186b67ce9339df337569d5",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/datacatalog/lineage/v1",
-      "lastGeneratedCommit": "b5cd5b2517482f1f3d09b89b901accd4f15cb265",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/datacatalog/v1",
-      "lastGeneratedCommit": "34d78f08e32be18b731c5065b67758ff8a0e8db7",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/datafusion/v1",
-      "lastGeneratedCommit": "336fb2d15f9beda2903e092199fd312649e5482e",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/dataflow/v1beta3",
-      "lastGeneratedCommit": "6fb68312dc1372cbc497f0e5294c94945879736c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/dataform/v1beta1",
-      "lastGeneratedCommit": "6fb68312dc1372cbc497f0e5294c94945879736c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/dataplex/v1",
-      "lastGeneratedCommit": "8e62267f7710bd927871e03a52700894e27df553",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/dataproc/v1",
-      "lastGeneratedCommit": "2f49d448f995c57186bec996ddc1bb50b1944f6c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/datastore/admin/v1",
-      "lastGeneratedCommit": "cead73336b652505e12689826d9ad037eb8852b0",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/datastore/v1",
-      "lastGeneratedCommit": "2196d4843a22befdc7bc3b7b676eeb392c31b3cf",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/datastream/v1",
-      "lastGeneratedCommit": "5c2ccb6470e6a483f73c1be39b3d185e15d11808",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/datastream/v1alpha1",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/deploy/v1",
-      "lastGeneratedCommit": "99a5e296c891faa79784687422b9d555bcf54a3f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/containeranalysis/v1",
-      "lastGeneratedCommit": "8ea348f641af88cd703023f72a857497c206a229",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/developerconnect/v1",
-      "lastGeneratedCommit": "5708c1af08f48f00c0104b516fce856a3405299d",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/dialogflow/cx/v3",
-      "lastGeneratedCommit": "dc219758b92d84a58e46228cc32654027e31d8b3",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/dialogflow/v2",
-      "lastGeneratedCommit": "2dee81b474957f04a0c277f6bf91cfeb13f12f55",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/dialogflow/v2beta1",
-      "lastGeneratedCommit": "7dd0554109b347addff64d4bed93903e6ff4e18a",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/discoveryengine/v1",
-      "lastGeneratedCommit": "537fd482f6bb8afb3a146d9b21673a8eb27958bd",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/discoveryengine/v1beta",
-      "lastGeneratedCommit": "e6b6ff9b7b3659641488e772355cdc78aac488ff",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/privacy/dlp/v2",
-      "lastGeneratedCommit": "4c44b3061bb776caeeb5b73307786678e6191e05",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/documentai/v1",
-      "lastGeneratedCommit": "4a6b902f1ec46023528873f5c776a74764cdd9cb",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/documentai/v1beta3",
-      "lastGeneratedCommit": "833292d3900ea08c9b5e3fd2dcf3c94e288aac3e",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/domains/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/domains/v1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/edgenetwork/v1",
-      "lastGeneratedCommit": "7310c46ada62661d6a64c899738315f28feb031b",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/enterpriseknowledgegraph/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/clouderrorreporting/v1beta1",
-      "lastGeneratedCommit": "72b72389895f0c4da476e04625a45b898952a873",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/essentialcontacts/v1",
-      "lastGeneratedCommit": "f78cd2f7943b9a2eb9734e56a8f3428da75917e2",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/eventarc/publishing/v1",
-      "lastGeneratedCommit": "e6b6ff9b7b3659641488e772355cdc78aac488ff",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/eventarc/v1",
-      "lastGeneratedCommit": "86ab4967ddb5cd045ad735787cfc8453b335009a",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/filestore/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/firestore/admin/v1",
-      "lastGeneratedCommit": "3776db131e34e42ec8d287203020cb4282166aa5",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/firestore/v1",
-      "lastGeneratedCommit": "28685f723d37bea3115876d423e7dbf70819e3ed",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/functions/v1",
-      "lastGeneratedCommit": "7767c573e4fffa76310a876cc9d7995a74c37481",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/functions/v2",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/functions/v2beta",
-      "lastGeneratedCommit": "182e5df1cc85f74cba78c5d974eb1f77092d57a6",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/gsuiteaddons/v1",
-      "lastGeneratedCommit": "d196cb2d69e542020101d8a30f1e33497835a4f1",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/gdchardwaremanagement/v1alpha",
-      "lastGeneratedCommit": "dee637f66f813b7f5dbdbdd8a1d1d23a2094144e",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/gkebackup/v1",
-      "lastGeneratedCommit": "b5cd5b2517482f1f3d09b89b901accd4f15cb265",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/gkeconnect/gateway/v1",
-      "lastGeneratedCommit": "de97a5f806a215960023d8d184a733260f8a9d3f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/gkehub/v1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/gkehub/v1",
-      "lastGeneratedCommit": "2eb3b6ab154343dd08512d3d3e7977873132d3af",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/gkemulticloud/v1",
-      "lastGeneratedCommit": "ba1a1c7a863a59e2c3ce6d95eb25d1c546320446",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/iam/admin/v1",
-      "lastGeneratedCommit": "3b84c01b5b0b38ef6bc1bf82ce43901be8c927e1",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/iam/credentials/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/iam/v1",
-      "lastGeneratedCommit": "b3fbe472cc3601bfdac9104af5529c93250f8c49",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/iam/v2",
-      "lastGeneratedCommit": "cead73336b652505e12689826d9ad037eb8852b0",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/iap/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/ids/v1",
-      "lastGeneratedCommit": "4b9324d4f8b719761b9e55dc5034def3c43009ab",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/kms/inventory/v1",
-      "lastGeneratedCommit": "cead73336b652505e12689826d9ad037eb8852b0",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/kms/v1",
-      "lastGeneratedCommit": "882633d32e4d772a08f62045d5d61173bef3026e",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/language/v1",
-      "lastGeneratedCommit": "ae87dc8a3830f37d575e2cff577c9b5a4737176b",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/language/v2",
-      "lastGeneratedCommit": "ba245fa19c1e6f1f2a13055a437f0c815c061867",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/lifesciences/v2beta",
-      "lastGeneratedCommit": "6fb68312dc1372cbc497f0e5294c94945879736c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/location",
-      "lastGeneratedCommit": "8a5dedc9b6c33394633a4ab8cdd7b4d42d460139",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/logging/type",
-      "lastGeneratedCommit": "bb7263d2e6f9f51630852e2e6bf7aaa8fb5bae06",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/logging/v2",
-      "lastGeneratedCommit": "8a3158a2deb927097d01f617116229018bc14771",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/managedidentities/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/managedkafka/v1",
-      "lastGeneratedCommit": "ceb1dea16e3e81cef8fa7831cbbc08f6b21de83c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/mediatranslation/v1beta1",
-      "lastGeneratedCommit": "6fb68312dc1372cbc497f0e5294c94945879736c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/memcache/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/memcache/v1beta2",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/metastore/v1",
-      "lastGeneratedCommit": "0ba620b9973ca9da13dd4c96897819d424656595",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/metastore/v1alpha",
-      "lastGeneratedCommit": "43b523f8844cee4ac0fd9b7adec472f15141c5df",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/metastore/v1beta",
-      "lastGeneratedCommit": "43b523f8844cee4ac0fd9b7adec472f15141c5df",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/migrationcenter/v1",
-      "lastGeneratedCommit": "3b84c01b5b0b38ef6bc1bf82ce43901be8c927e1",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/monitoring/v3",
-      "lastGeneratedCommit": "4d95834e9db8ee827f0e7846b175a3aeaf92f9ef",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/netapp/v1",
-      "lastGeneratedCommit": "d0cdaf8097981ede7d8132e768229e02416d9974",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/networkconnectivity/v1",
-      "lastGeneratedCommit": "59254b411ac63bbb9bcd4a54cec10540ceaa5154",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/networkconnectivity/v1alpha1",
-      "lastGeneratedCommit": "59254b411ac63bbb9bcd4a54cec10540ceaa5154",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/networkmanagement/v1",
-      "lastGeneratedCommit": "d5cc1cd738a66bb7104162bcb35ebd539c658415",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/networksecurity/v1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/notebooks/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/notebooks/v1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/notebooks/v2",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/optimization/v1",
-      "lastGeneratedCommit": "a72f10c2674ff0e7c14763dbc57d5761c03bf6c9",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/oracledatabase/v1",
-      "lastGeneratedCommit": "3322b91056db2735074b230c926e6ef3a958aa53",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/orchestration/airflow/service/v1",
-      "lastGeneratedCommit": "8a75da84d67d7dc194ff81fbf8f48a2b07eee595",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/orgpolicy/v1",
-      "lastGeneratedCommit": "651af4b02f16b5c04c7c4f721d3533ca6869e7c8",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/orgpolicy/v2",
-      "lastGeneratedCommit": "0a87fe7bcf2c106bff0316384366b98cd2b2e2db",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/osconfig/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/osconfig/v1alpha",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/oslogin/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/oslogin/v1beta",
-      "lastGeneratedCommit": "e4e39feea63b5f0d646fc193acbf536b5d292b64",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/parallelstore/v1",
-      "lastGeneratedCommit": "e0cd5faa960c45f8af8310bad9c4494ed19b7617",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/parallelstore/v1beta",
-      "lastGeneratedCommit": "52e410823122cf44d265c3beecb86c773db248a2",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/phishingprotection/v1beta1",
-      "lastGeneratedCommit": "06719db0111829b0d350a0323c00e2976d74df19",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/policysimulator/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/policytroubleshooter/iam/v3",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/policytroubleshooter/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/privatecatalog/v1beta1",
-      "lastGeneratedCommit": "6fb68312dc1372cbc497f0e5294c94945879736c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/privilegedaccessmanager/v1",
-      "lastGeneratedCommit": "aa3dd2bc6cbb44fa75443ddf44e73b6d36a90766",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/cloudprofiler/v2",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/pubsub/v1",
-      "lastGeneratedCommit": "40bc86036e483ab04e5bc83ac7519e15d68cbd05",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/rapidmigrationassessment/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/recaptchaenterprise/v1",
-      "lastGeneratedCommit": "2dee81b474957f04a0c277f6bf91cfeb13f12f55",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/recaptchaenterprise/v1beta1",
-      "lastGeneratedCommit": "c76e13d561f3cc34349b1b1498c5815350883083",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/recommendationengine/v1beta1",
-      "lastGeneratedCommit": "6fb68312dc1372cbc497f0e5294c94945879736c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/recommender/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/redis/cluster/v1",
-      "lastGeneratedCommit": "d4c6826b966464a3e7e272bb44d7ed563b5abe81",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/redis/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/redis/v1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/resourcemanager/v3",
-      "lastGeneratedCommit": "b5cd5b2517482f1f3d09b89b901accd4f15cb265",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/retail/v2",
-      "lastGeneratedCommit": "d01eb4689472766df6822cdfcdb4412bfb4c2789",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/run/v2",
-      "lastGeneratedCommit": "3d194928f8427e6d33156f9193af053fe74f996d",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/scheduler/v1",
-      "lastGeneratedCommit": "47444ff0e3c8bca6c74ee0e8412aa747a9e0126d",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/secretmanager/v1",
-      "lastGeneratedCommit": "8c9639ac76d6f08df5b3c2c0aa759cab126bbba5",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/secretmanager/v1beta2",
-      "lastGeneratedCommit": "d27e7a1f954c265f2ce9180b582c12452b67396c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/secrets/v1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/securesourcemanager/v1",
-      "lastGeneratedCommit": "b6a9d807da8fb0f767a7b5b5b2d773e41e7d52b5",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/security/privateca/v1",
-      "lastGeneratedCommit": "bc2c0db12bf27fcccd0da86f6eb28be730b9f1fe",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/security/publicca/v1beta1",
-      "lastGeneratedCommit": "25a1a57957d9e4bf431897d280b2569b26dc9165",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/securitycenter/settings/v1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/securitycenter/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/securitycenter/v1p1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/securitycenter/v2",
-      "lastGeneratedCommit": "a14447dd79a8e21b9199ab654cb9c1b5a20eb35a",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/securitycentermanagement/v1",
-      "lastGeneratedCommit": "e6b6ff9b7b3659641488e772355cdc78aac488ff",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/api/servicecontrol/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/servicedirectory/v1",
-      "lastGeneratedCommit": "cdcc2207ed5be7c3aa6be8292c7fe5cb47809547",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/servicedirectory/v1beta1",
-      "lastGeneratedCommit": "a2bef5d1953f760d872398715f9c299b0ca5683f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/servicehealth/v1",
-      "lastGeneratedCommit": "09d410360ef6b9d92bda174d5b213a921546ee99",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/api/servicemanagement/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/api/serviceusage/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/shell/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/spanner/admin/database/v1",
-      "lastGeneratedCommit": "d57f2c114b2d1d3db7fa71a1333d72129f8fd1ae",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/spanner/admin/instance/v1",
-      "lastGeneratedCommit": "3db0452ba6b45012794e61640ea6eadd7153af74",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/spanner/v1",
-      "lastGeneratedCommit": "d46c6c9a8bf21dc69a19e1251b43aa8b6354a3b7",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/speech/v1",
-      "lastGeneratedCommit": "bf2a7ca1d46894df9ebccf5ad6338cbe9e21d9a8",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/speech/v1p1beta1",
-      "lastGeneratedCommit": "bf2a7ca1d46894df9ebccf5ad6338cbe9e21d9a8",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/speech/v2",
-      "lastGeneratedCommit": "ae87dc8a3830f37d575e2cff577c9b5a4737176b",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/storage/control/v2",
-      "lastGeneratedCommit": "3b9311b65c8224502ba67af7588167e7eb10a325",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/storage/v2",
-      "lastGeneratedCommit": "44ad570a9b4055b9b952c3d8fd476be6f95d8b0a",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/storageinsights/v1",
-      "lastGeneratedCommit": "740a723d67541a7917db5e2b017e4fd0e8d059fd",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/storagetransfer/v1",
-      "lastGeneratedCommit": "67495ab130490fec112841715649b86a7d335e6a",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/support/v2",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/talent/v4",
-      "lastGeneratedCommit": "c72d7385435589176aa6e44563fcfbc795b9a476",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/talent/v4beta1",
-      "lastGeneratedCommit": "528ea46081bccba0dcb89abd79362d3decfa37a9",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/tasks/v2",
-      "lastGeneratedCommit": "2dee81b474957f04a0c277f6bf91cfeb13f12f55",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/tasks/v2beta3",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/telcoautomation/v1",
-      "lastGeneratedCommit": "02ff451735116e113ded13f6dcbf1c8fb03ba3c8",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/texttospeech/v1",
-      "lastGeneratedCommit": "2dee81b474957f04a0c277f6bf91cfeb13f12f55",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/texttospeech/v1beta1",
-      "lastGeneratedCommit": "d985436b77cfd0231bb170014e4eadc19392d3ff",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/tpu/v1",
-      "lastGeneratedCommit": "c3556b45dc35a145e04b5692bc72e01a4f58a6b2",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/cloudtrace/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/devtools/cloudtrace/v2",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/translate/v3",
-      "lastGeneratedCommit": "ae87dc8a3830f37d575e2cff577c9b5a4737176b",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/vmmigration/v1",
-      "lastGeneratedCommit": "a7f393252475ff3ffe53850e5a6eebe8ead3d5d6",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/video/livestream/v1",
-      "lastGeneratedCommit": "19577edb4d439db98d2fb1f6f48f2e1b29fba099",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/video/stitcher/v1",
-      "lastGeneratedCommit": "740a723d67541a7917db5e2b017e4fd0e8d059fd",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/video/transcoder/v1",
-      "lastGeneratedCommit": "1b4bd4d3eb47ab9cb94f03a6e096f2e93c9c09a2",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/videointelligence/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/vision/v1",
-      "lastGeneratedCommit": "ae87dc8a3830f37d575e2cff577c9b5a4737176b",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/vmwareengine/v1",
-      "lastGeneratedCommit": "db2ac7a5afc0d859b102f2334abda6761a0ab62d",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/vpcaccess/v1",
-      "lastGeneratedCommit": "0a250ef2318e97b1b3153423e7af0fdbe5731741",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/webrisk/v1",
-      "lastGeneratedCommit": "76ffdb2287ad9fc2bf2932169e3542ca82d6669f",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/webrisk/v1beta1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/websecurityscanner/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/workflows/executions/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/workflows/executions/v1beta",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/workflows/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/workflows/v1beta",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/cloud/workstations/v1",
-      "lastGeneratedCommit": "7f27ba9f1430814e1744b1c8b8161ae6dd09d8b6",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/identity/accesscontextmanager/type",
-      "lastGeneratedCommit": "9148cf28f640e6a9d4e72b1f9a34e4d9cfa19244",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/identity/accesscontextmanager/v1",
-      "lastGeneratedCommit": "af75aa920034a998c4c935d8c8693ae6959f5f64",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/longrunning",
-      "lastGeneratedCommit": "42f85a600ad8c8610f2849c7bfd8fb4e27978083",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/maps/addressvalidation/v1",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/maps/fleetengine/delivery/v1",
-      "lastGeneratedCommit": "e9a4c38a81933108eaa6ac96c7ead31e253c8c64",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/maps/fleetengine/v1",
-      "lastGeneratedCommit": "e9a4c38a81933108eaa6ac96c7ead31e253c8c64",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/maps/mapsplatformdatasets/v1",
-      "lastGeneratedCommit": "ce39e78569ce4425237781756a6de6b2a628f555",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/maps/places/v1",
-      "lastGeneratedCommit": "280725e991516d4a0f136268faf5aa6d32d21b54",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/maps/routeoptimization/v1",
-      "lastGeneratedCommit": "82d07c3ee426bcea98c16d1c40ab5b556b2a01f4",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/maps/routing/v2",
-      "lastGeneratedCommit": "a3211f3342219aad1b310ec1739476586384473a",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/css/v1",
-      "lastGeneratedCommit": "892e72fb31d9c063f9b992bfd923730094233ed0",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/accounts/v1beta",
-      "lastGeneratedCommit": "1b2f804bf43253118ff0e56f9524979265afdfe6",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/conversions/v1beta",
-      "lastGeneratedCommit": "0ed8e060147c90feeeac57b2c35114d407257ed8",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/datasources/v1beta",
-      "lastGeneratedCommit": "51b9a3d9858ab4ecdfa325e13d74a4b46abcd377",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/inventories/v1beta",
-      "lastGeneratedCommit": "657d99eff7c05e7a4e22639b562b423a92ebc55c",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/lfp/v1beta",
-      "lastGeneratedCommit": "958ef9d7846b6ec6da7ca274a8db6841ebb1b0aa",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/notifications/v1beta",
-      "lastGeneratedCommit": "09848563c56a70af398ee6a1877f36cc65cb41a2",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/products/v1beta",
-      "lastGeneratedCommit": "0f1beb9507162a4cbe3a2b1437922a6289ae5f24",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/quota/v1beta",
-      "lastGeneratedCommit": "3d50414a7ff3f0b8ffe8ad7858257396e4f18131",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/reports/v1beta",
-      "lastGeneratedCommit": "57514fbcb92c243fc478fdd540e5bf40bd91bf64",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/merchant/reviews/v1beta",
-      "lastGeneratedCommit": "44c31c613b359211918a2ddb677e20b23da5a282",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "google/shopping/type",
-      "lastGeneratedCommit": "3597f7db2191c00b100400991ef96e52d62f5841",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    },
-    {
-      "id": "grafeas/v1",
-      "lastGeneratedCommit": "ad5c47728cac14fc75d152b2736c4872637e7a6d",
-      "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
-    }
-  ]
+    "imageTag": "latest",
+    "apiGenerationStates": [
+        {
+            "id": "google/ads/admanager/v1",
+            "lastGeneratedCommit": "0b8fa5230f3f04e3ea8aa8343f21b505bb2b7a10",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/marketingplatform/admin/v1alpha",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/analytics/admin/v1alpha",
+            "lastGeneratedCommit": "0c50144b96ad0ad65c6fd26f34253b129154ec32",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/analytics/admin/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/analytics/data/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/apps/card/v1",
+            "lastGeneratedCommit": "436a34a5da04978e98859afe7487ce93d08e9c03",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/chat/v1",
+            "lastGeneratedCommit": "76254e64ecb69baa17bac426dd3d98e34daa60b9",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/apps/events/subscriptions/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/apps/meet/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/apps/meet/v2beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/apps/script/type",
+            "lastGeneratedCommit": "d606bb4a7852604e4045948d6340e73cb0d1d70b",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/area120/tables/v1alpha1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/accessapproval/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/advisorynotifications/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/alloydb/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/alloydb/v1alpha",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/alloydb/v1beta",
+            "lastGeneratedCommit": "6155d42e99f45ebf53100d492852be1561916137",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/apigateway/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/aiplatform/v1beta1",
+            "lastGeneratedCommit": "2c2a335e10b6b35b02b28dd1004ebdc94790d14d",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/aiplatform/v1",
+            "lastGeneratedCommit": "2c2a335e10b6b35b02b28dd1004ebdc94790d14d",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/apihub/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/api/apikeys/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/apigeeconnect/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/apigeeregistry/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/appengine/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/apphub/v1",
+            "lastGeneratedCommit": "c15e2b199067905e2c9372da116a0d83ac003c1b",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/artifactregistry/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/artifactregistry/v1beta2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/asset/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/assuredworkloads/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/assuredworkloads/v1beta1",
+            "lastGeneratedCommit": "12fc2f929e39688aa24ae6fc5e18db3315975a6e",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/audit",
+            "lastGeneratedCommit": "b58548982b1622f19e2a6ca52a509acb718c499f",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/automl/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/backupdr/v1",
+            "lastGeneratedCommit": "c15e2b199067905e2c9372da116a0d83ac003c1b",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/baremetalsolution/v2",
+            "lastGeneratedCommit": "6caf69b6f1d3f80255fa46e504acf96e38ef34c0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/batch/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/batch/v1alpha",
+            "lastGeneratedCommit": "c15e2b199067905e2c9372da116a0d83ac003c1b",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/beyondcorp/appconnections/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/beyondcorp/appconnectors/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/beyondcorp/appgateways/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/beyondcorp/clientgateways/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/analyticshub/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/connection/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/dataexchange/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/datapolicies/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/datapolicies/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/datatransfer/v1",
+            "lastGeneratedCommit": "12fc2f929e39688aa24ae6fc5e18db3315975a6e",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/migration/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/reservation/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/bigquery/storage/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/bigtable/admin/v2",
+            "lastGeneratedCommit": "b80f49d1bcb3b0f1de695d2d093ad3a43ac59f3b",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/bigtable/v2",
+            "lastGeneratedCommit": "47d236a058fee1cf4cab357c852dc935d095bb69",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/billing/budgets/v1",
+            "lastGeneratedCommit": "12fc2f929e39688aa24ae6fc5e18db3315975a6e",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/billing/budgets/v1beta1",
+            "lastGeneratedCommit": "12fc2f929e39688aa24ae6fc5e18db3315975a6e",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/billing/v1",
+            "lastGeneratedCommit": "12fc2f929e39688aa24ae6fc5e18db3315975a6e",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/binaryauthorization/v1",
+            "lastGeneratedCommit": "12fc2f929e39688aa24ae6fc5e18db3315975a6e",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/binaryauthorization/v1beta1",
+            "lastGeneratedCommit": "3f103ea2269aafa78eca65d29092870d1eb61d48",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/certificatemanager/v1",
+            "lastGeneratedCommit": "3f103ea2269aafa78eca65d29092870d1eb61d48",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/channel/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/cloudbuild/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/cloudbuild/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/cloudcontrolspartner/v1",
+            "lastGeneratedCommit": "554575ee8d01d277344ec704e0561e9abc7f57f3",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/cloudcontrolspartner/v1beta",
+            "lastGeneratedCommit": "554575ee8d01d277344ec704e0561e9abc7f57f3",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/clouddms/v1",
+            "lastGeneratedCommit": "3f103ea2269aafa78eca65d29092870d1eb61d48",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/api/cloudquotas/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/api/cloudquotas/v1beta",
+            "lastGeneratedCommit": "984bf3328ad91408a0c543a89ae6caefec92f31d",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/commerce/consumer/procurement/v1",
+            "lastGeneratedCommit": "3f103ea2269aafa78eca65d29092870d1eb61d48",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/common",
+            "lastGeneratedCommit": "42c04fea4338ba626095ec2cde5ea75827191581",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/compute/v1",
+            "lastGeneratedCommit": "2753fe1683a42442aa7a4b778c416c886a647fe6",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/confidentialcomputing/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/confidentialcomputing/v1alpha1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/config/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/connectors/v1",
+            "lastGeneratedCommit": "6caf69b6f1d3f80255fa46e504acf96e38ef34c0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/contactcenterinsights/v1",
+            "lastGeneratedCommit": "12fc2f929e39688aa24ae6fc5e18db3315975a6e",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/container/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/datacatalog/lineage/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/datacatalog/v1",
+            "lastGeneratedCommit": "c18eb9fd055def47dcf2e26ffc06fdb02f9d15c7",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/datafusion/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/dataflow/v1beta3",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/dataform/v1beta1",
+            "lastGeneratedCommit": "e7e526513dc435f0386358bd5354f3de6ced6380",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/dataplex/v1",
+            "lastGeneratedCommit": "2415cfc65c4a5eb495117d5577ff5637a36436ed",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/dataproc/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/datastore/admin/v1",
+            "lastGeneratedCommit": "d72ca0d2ef7a786e2ffd59fa04e1c9241e09a7a9",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/datastore/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/datastream/v1",
+            "lastGeneratedCommit": "2dc21fecf8709ee1e7937e8be3a9a136a1fdb613",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/datastream/v1alpha1",
+            "lastGeneratedCommit": "2dc21fecf8709ee1e7937e8be3a9a136a1fdb613",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/deploy/v1",
+            "lastGeneratedCommit": "d9b049376b49f7ccf0dc0564c83357dd862f9b01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/containeranalysis/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/developerconnect/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/dialogflow/cx/v3",
+            "lastGeneratedCommit": "df58085901d8fb80c2c021e405923bb2351a6f29",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/dialogflow/v2",
+            "lastGeneratedCommit": "c57048e5e01822cbac85d8d16660cd096454d00f",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/dialogflow/v2beta1",
+            "lastGeneratedCommit": "aee4464e15a44884a98ad737a007918a95764c93",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/discoveryengine/v1",
+            "lastGeneratedCommit": "588b7c25259a86720d072607a51f41151d9832e6",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/discoveryengine/v1beta",
+            "lastGeneratedCommit": "ff32775da010bcdcb25779f3fa32dbccbeec61b8",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/privacy/dlp/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/documentai/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/documentai/v1beta3",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/domains/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/domains/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/edgenetwork/v1",
+            "lastGeneratedCommit": "2dc21fecf8709ee1e7937e8be3a9a136a1fdb613",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/enterpriseknowledgegraph/v1",
+            "lastGeneratedCommit": "3f103ea2269aafa78eca65d29092870d1eb61d48",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/clouderrorreporting/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/essentialcontacts/v1",
+            "lastGeneratedCommit": "2dc21fecf8709ee1e7937e8be3a9a136a1fdb613",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/eventarc/publishing/v1",
+            "lastGeneratedCommit": "5d0c7bf00477b653d4c79718b38e95e5a90768d8",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/eventarc/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/filestore/v1",
+            "lastGeneratedCommit": "607b7624f5d22202c601331465eb053833b4bf99",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/firestore/admin/v1",
+            "lastGeneratedCommit": "fd510f8e0f12ef5e2f77be2dd4b6316d39952a37",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/firestore/v1",
+            "lastGeneratedCommit": "fd510f8e0f12ef5e2f77be2dd4b6316d39952a37",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/functions/v1",
+            "lastGeneratedCommit": "2dc21fecf8709ee1e7937e8be3a9a136a1fdb613",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/functions/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/functions/v2beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/gsuiteaddons/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/gdchardwaremanagement/v1alpha",
+            "lastGeneratedCommit": "2dc21fecf8709ee1e7937e8be3a9a136a1fdb613",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/gkebackup/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/gkeconnect/gateway/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/gkehub/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/gkehub/v1",
+            "lastGeneratedCommit": "3f103ea2269aafa78eca65d29092870d1eb61d48",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/gkemulticloud/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/iam/admin/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/iam/credentials/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/iam/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/iam/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/iap/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/ids/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/kms/inventory/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/kms/v1",
+            "lastGeneratedCommit": "a2dbd2daf634a4841d98ce2ef77aea8e673e71e5",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/language/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/language/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/lifesciences/v2beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/location",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/logging/type",
+            "lastGeneratedCommit": "95da686e8840cf3edf872ce3d095967e24e41bf6",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/logging/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/managedidentities/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/managedkafka/v1",
+            "lastGeneratedCommit": "8f7e301d346ba792a9bd282f8d62db7fad87cb8a",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/mediatranslation/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/memcache/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/memcache/v1beta2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/memorystore/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/memorystore/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/metastore/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/metastore/v1alpha",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/metastore/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/migrationcenter/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/monitoring/v3",
+            "lastGeneratedCommit": "af33708d72bb5f41d12110d89305e43f9460969d",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/netapp/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/networkconnectivity/v1",
+            "lastGeneratedCommit": "3f103ea2269aafa78eca65d29092870d1eb61d48",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/networkconnectivity/v1alpha1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/networkmanagement/v1",
+            "lastGeneratedCommit": "2852893d4b201896afb5ac4047205c9163f5c8fa",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/networksecurity/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/networkservices/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/notebooks/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/notebooks/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/notebooks/v2",
+            "lastGeneratedCommit": "d41317895717b9ebc3b04d42cafbb0eaef080329",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/optimization/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/oracledatabase/v1",
+            "lastGeneratedCommit": "e4515ba9ef4f8d75d6d38de3a2b3fe6654705b26",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/orchestration/airflow/service/v1",
+            "lastGeneratedCommit": "aafb43c2088fae86421aa8e98d19869c4159737d",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/orgpolicy/v1",
+            "lastGeneratedCommit": "d02e58244db5d01607ec2ad52a47e7edce8612f0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/orgpolicy/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/osconfig/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/osconfig/v1alpha",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/oslogin/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/oslogin/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/parallelstore/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/parallelstore/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/parametermanager/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/phishingprotection/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/policysimulator/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/policytroubleshooter/iam/v3",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/policytroubleshooter/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/privatecatalog/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/privilegedaccessmanager/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/cloudprofiler/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/pubsub/v1",
+            "lastGeneratedCommit": "263055cc1fc36dc2828e50eb7a92d75b1e0e4af5",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/rapidmigrationassessment/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/recaptchaenterprise/v1",
+            "lastGeneratedCommit": "5b8c54e53d8d05f5a75e3f21ac5518b23878b696",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/recaptchaenterprise/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/recommendationengine/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/recommender/v1",
+            "lastGeneratedCommit": "d41317895717b9ebc3b04d42cafbb0eaef080329",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/redis/cluster/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/redis/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/redis/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/resourcemanager/v3",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/retail/v2",
+            "lastGeneratedCommit": "3bb047a19d03f94176f733954b148c81839904ab",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/run/v2",
+            "lastGeneratedCommit": "b4f2cb5295c6cd7b4f0366514508f70304c48a21",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/scheduler/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/secretmanager/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/secretmanager/v1beta2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/secrets/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/securesourcemanager/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/security/privateca/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/security/publicca/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/security/publicca/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/securitycenter/settings/v1beta1",
+            "lastGeneratedCommit": "35af68f36aeb2c79978680fdc4549740d425dc2a",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/securitycenter/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/securitycenter/v1p1beta1",
+            "lastGeneratedCommit": "696d1c237cabe450c4369e867d68c98e45aec4bf",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/securitycenter/v2",
+            "lastGeneratedCommit": "44245d16a7eeac52c7700705dba591ede3a13180",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/securitycentermanagement/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/api/servicecontrol/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/servicedirectory/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/servicedirectory/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/servicehealth/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/api/servicemanagement/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/api/serviceusage/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/shell/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/spanner/admin/database/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/spanner/admin/instance/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/spanner/v1",
+            "lastGeneratedCommit": "fd510f8e0f12ef5e2f77be2dd4b6316d39952a37",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/speech/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/speech/v1p1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/speech/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/storage/control/v2",
+            "lastGeneratedCommit": "1f01eefb40000d70b0c58314709af1d4f8222cc0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/storage/v2",
+            "lastGeneratedCommit": "44ad570a9b4055b9b952c3d8fd476be6f95d8b0a",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/storageinsights/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/storagetransfer/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/support/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/talent/v4",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/talent/v4beta1",
+            "lastGeneratedCommit": "acfcb5c24465dd88dd18767a9baa496a2c47fdb1",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/tasks/v2",
+            "lastGeneratedCommit": "b151ec2ae29c2c955c56784c0ce388b2d8c4a84c",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/tasks/v2beta3",
+            "lastGeneratedCommit": "b151ec2ae29c2c955c56784c0ce388b2d8c4a84c",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/telcoautomation/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/texttospeech/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/texttospeech/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/tpu/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/cloudtrace/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/devtools/cloudtrace/v2",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/translate/v3",
+            "lastGeneratedCommit": "b151ec2ae29c2c955c56784c0ce388b2d8c4a84c",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/vmmigration/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/video/livestream/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/video/stitcher/v1",
+            "lastGeneratedCommit": "696d1c237cabe450c4369e867d68c98e45aec4bf",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/video/transcoder/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/videointelligence/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/vision/v1",
+            "lastGeneratedCommit": "35af68f36aeb2c79978680fdc4549740d425dc2a",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/visionai/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/vmwareengine/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/vpcaccess/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/webrisk/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/webrisk/v1beta1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/websecurityscanner/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/workflows/executions/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/workflows/executions/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/workflows/v1",
+            "lastGeneratedCommit": "d7db9c6f0c5a52efda18e8cc3e3e8e6a67ee3b5c",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/workflows/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/cloud/workstations/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/identity/accesscontextmanager/type",
+            "lastGeneratedCommit": "e7d77d65f0e05ce584c1a824c7ecab53b411498b",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/identity/accesscontextmanager/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/longrunning",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/maps/addressvalidation/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/maps/areainsights/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/maps/fleetengine/delivery/v1",
+            "lastGeneratedCommit": "fc5c0bd8845ea19a288580e246f8a2786f4416cc",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/maps/fleetengine/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/maps/mapsplatformdatasets/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/maps/places/v1",
+            "lastGeneratedCommit": "b3d8e7d376b864efeef6e6ee15805763dfa2b47d",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/maps/routeoptimization/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/maps/routing/v2",
+            "lastGeneratedCommit": "c163d9caf0ab927a9ff072cf5adafc57a9e34330",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/css/v1",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/accounts/v1beta",
+            "lastGeneratedCommit": "fa2198128e162a80ff7ea56d46ef0b254af4980b",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/conversions/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/datasources/v1beta",
+            "lastGeneratedCommit": "b2fc92c85219ec4283b877abdfef688269d26e8a",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/inventories/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/lfp/v1beta",
+            "lastGeneratedCommit": "d72ca0d2ef7a786e2ffd59fa04e1c9241e09a7a9",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/notifications/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/products/v1beta",
+            "lastGeneratedCommit": "bc7f715d7f58afe381fbc244a8bcde7f0afa11ed",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/promotions/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/quota/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/reports/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/merchant/reviews/v1beta",
+            "lastGeneratedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "google/shopping/type",
+            "lastGeneratedCommit": "a3a2dc62816053b6e9dc2b67d52048133794b178",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        },
+        {
+            "id": "grafeas/v1",
+            "lastGeneratedCommit": "ad5c47728cac14fc75d152b2736c4872637e7a6d",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
+        }
+    ],
+    "libraryReleaseStates": [
+        {
+            "id": "Google.Ads.AdManager.V1",
+            "currentVersion": "1.0.0-beta01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-03T15:36:23Z",
+            "apis": [
+                {
+                    "apiId": "google/ads/admanager/v1",
+                    "lastReleasedCommit": "672cd6a381c7a0aea16438e2335dc7799bd70e4d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Ads.AdManager.V1/Google.Ads.AdManager.V1"
+            ]
+        },
+        {
+            "id": "Google.Ads.MarketingPlatform.Admin.V1Alpha",
+            "currentVersion": "1.0.0-alpha01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-19T07:02:24Z",
+            "apis": [
+                {
+                    "apiId": "google/marketingplatform/admin/v1alpha",
+                    "lastReleasedCommit": "34133c71bc5e5576db84e255cf181a96f0752521"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Ads.MarketingPlatform.Admin.V1Alpha/Google.Ads.MarketingPlatform.Admin.V1Alpha"
+            ]
+        },
+        {
+            "id": "Google.Analytics.Admin.V1Alpha",
+            "currentVersion": "2.0.0-alpha22",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-10T18:34:26Z",
+            "apis": [
+                {
+                    "apiId": "google/analytics/admin/v1alpha",
+                    "lastReleasedCommit": "0c50144b96ad0ad65c6fd26f34253b129154ec32"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Analytics.Admin.V1Alpha/Google.Analytics.Admin.V1Alpha"
+            ]
+        },
+        {
+            "id": "Google.Analytics.Admin.V1Beta",
+            "currentVersion": "1.0.0-beta09",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-03T17:52:26Z",
+            "apis": [
+                {
+                    "apiId": "google/analytics/admin/v1beta",
+                    "lastReleasedCommit": "89a0f8e22df3d09eb1a283a32cb3772ad2553fce"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Analytics.Admin.V1Beta/Google.Analytics.Admin.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Analytics.Data.V1Beta",
+            "currentVersion": "2.0.0-beta09",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-05T08:20:20Z",
+            "apis": [
+                {
+                    "apiId": "google/analytics/data/v1beta",
+                    "lastReleasedCommit": "3a6c7dcb9e3bc6792bb9b41939a8dd2bbd6dcaf9"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Analytics.Data.V1Beta/Google.Analytics.Data.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Apps.Card.V1",
+            "currentVersion": "1.0.0-beta01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-04-17T16:56:21Z",
+            "apis": [
+                {
+                    "apiId": "google/apps/card/v1",
+                    "lastReleasedCommit": "436a34a5da04978e98859afe7487ce93d08e9c03"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Apps.Card.V1/Google.Apps.Card.V1"
+            ]
+        },
+        {
+            "id": "Google.Apps.Chat.V1",
+            "currentVersion": "1.0.0-beta13",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-10T18:30:23Z",
+            "apis": [
+                {
+                    "apiId": "google/chat/v1",
+                    "lastReleasedCommit": "76254e64ecb69baa17bac426dd3d98e34daa60b9"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Apps.Chat.V1/Google.Apps.Chat.V1"
+            ]
+        },
+        {
+            "id": "Google.Apps.Events.Subscriptions.V1",
+            "currentVersion": "1.0.0-beta03",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T16:40:23Z",
+            "apis": [
+                {
+                    "apiId": "google/apps/events/subscriptions/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Apps.Events.Subscriptions.V1/Google.Apps.Events.Subscriptions.V1"
+            ]
+        },
+        {
+            "id": "Google.Apps.Meet.V2",
+            "currentVersion": "1.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-03T18:02:22Z",
+            "apis": [
+                {
+                    "apiId": "google/apps/meet/v2",
+                    "lastReleasedCommit": "6dedc0542a0986dcc7b977b20399cdcbb1bdb4bb"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Apps.Meet.V2/Google.Apps.Meet.V2"
+            ]
+        },
+        {
+            "id": "Google.Apps.Meet.V2Beta",
+            "currentVersion": "1.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-03T18:12:22Z",
+            "apis": [
+                {
+                    "apiId": "google/apps/meet/v2beta",
+                    "lastReleasedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Apps.Meet.V2Beta/Google.Apps.Meet.V2Beta"
+            ]
+        },
+        {
+            "id": "Google.Apps.Script.Type",
+            "currentVersion": "2.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-26T17:18:20Z",
+            "apis": [
+                {
+                    "apiId": "google/apps/script/type",
+                    "lastReleasedCommit": "4899fc0b6235b2f0dc873e59fcc0b9a468cba2a1"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Apps.Script.Type/Google.Apps.Script.Type"
+            ]
+        },
+        {
+            "id": "Google.Area120.Tables.V1Alpha1",
+            "currentVersion": "2.0.0-alpha05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T16:46:21Z",
+            "apis": [
+                {
+                    "apiId": "google/area120/tables/v1alpha1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Area120.Tables.V1Alpha1/Google.Area120.Tables.V1Alpha1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AccessApproval.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:02:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/accessapproval/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AccessApproval.V1/Google.Cloud.AccessApproval.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AdvisoryNotifications.V1",
+            "currentVersion": "1.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:04:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/advisorynotifications/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AdvisoryNotifications.V1/Google.Cloud.AdvisoryNotifications.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AlloyDb.V1",
+            "currentVersion": "1.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-29T16:56:28Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/alloydb/v1",
+                    "lastReleasedCommit": "113ddfebbe8d4e0639eb19fe91817a13edfc0c5c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AlloyDb.V1/Google.Cloud.AlloyDb.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AlloyDb.V1Alpha",
+            "currentVersion": "1.0.0-alpha10",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-11-18T19:36:31Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/alloydb/v1alpha",
+                    "lastReleasedCommit": "1f3eb168e3fc43799e45e6e9df36cb3298e1d605"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AlloyDb.V1Alpha/Google.Cloud.AlloyDb.V1Alpha"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AlloyDb.V1Beta",
+            "currentVersion": "1.0.0-beta09",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-11-18T19:34:39Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/alloydb/v1beta",
+                    "lastReleasedCommit": "1f3eb168e3fc43799e45e6e9df36cb3298e1d605"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AlloyDb.V1Beta/Google.Cloud.AlloyDb.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ApiGateway.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:00:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/apigateway/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ApiGateway.V1/Google.Cloud.ApiGateway.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AIPlatform.V1Beta1",
+            "currentVersion": "1.0.0-beta22",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:52:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/aiplatform/v1beta1",
+                    "lastReleasedCommit": "2c2a335e10b6b35b02b28dd1004ebdc94790d14d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AIPlatform.V1Beta1/Google.Cloud.AIPlatform.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AIPlatform.V1",
+            "currentVersion": "3.23.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:52:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/aiplatform/v1",
+                    "lastReleasedCommit": "2c2a335e10b6b35b02b28dd1004ebdc94790d14d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AIPlatform.V1/Google.Cloud.AIPlatform.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ApiHub.V1",
+            "currentVersion": "1.0.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-05T19:04:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/apihub/v1",
+                    "lastReleasedCommit": "8c6de209d316e7a33fcd28e743ae893c83b17eed"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ApiHub.V1/Google.Cloud.ApiHub.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ApiKeys.V2",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:12:16Z",
+            "apis": [
+                {
+                    "apiId": "google/api/apikeys/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ApiKeys.V2/Google.Cloud.ApiKeys.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ApigeeConnect.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:00:31Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/apigeeconnect/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ApigeeConnect.V1/Google.Cloud.ApigeeConnect.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ApigeeRegistry.V1",
+            "currentVersion": "1.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:10:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/apigeeregistry/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ApigeeRegistry.V1/Google.Cloud.ApigeeRegistry.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AppEngine.Logging.V1",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-27T16:18:16Z",
+            "apis": [
+                {
+                    "apiId": "google/appengine/logging/v1",
+                    "lastReleasedCommit": "4221b78ecddf8edf168ff2817ed6c14dd844ae2c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AppEngine.Logging.V1/Google.Cloud.AppEngine.Logging.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AppEngine.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:04:22Z",
+            "apis": [
+                {
+                    "apiId": "google/appengine/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AppEngine.V1/Google.Cloud.AppEngine.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AppHub.V1",
+            "currentVersion": "1.0.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-05T19:02:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/apphub/v1",
+                    "lastReleasedCommit": "54d659d0ae74f39e92755948b821a1495b3cb3c8"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ArtifactRegistry.V1",
+            "currentVersion": "2.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-29T16:58:27Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/artifactregistry/v1",
+                    "lastReleasedCommit": "5dc10a42f836b42b091088408ab3e17172ce7359"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ArtifactRegistry.V1/Google.Cloud.ArtifactRegistry.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ArtifactRegistry.V1Beta2",
+            "currentVersion": "2.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:00:36Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/artifactregistry/v1beta2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ArtifactRegistry.V1Beta2/Google.Cloud.ArtifactRegistry.V1Beta2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Asset.V1",
+            "currentVersion": "3.12.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:02:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/asset/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Asset.V1/Google.Cloud.Asset.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AssuredWorkloads.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:58:18Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/assuredworkloads/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AssuredWorkloads.V1/Google.Cloud.AssuredWorkloads.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AssuredWorkloads.V1Beta1",
+            "currentVersion": "2.0.0-beta08",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T16:44:32Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/assuredworkloads/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AssuredWorkloads.V1Beta1/Google.Cloud.AssuredWorkloads.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Audit",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-11T07:04:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/audit",
+                    "lastReleasedCommit": "b58548982b1622f19e2a6ca52a509acb718c499f"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Audit/Google.Cloud.Audit"
+            ]
+        },
+        {
+            "id": "Google.Cloud.AutoML.V1",
+            "currentVersion": "3.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:14:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/automl/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.AutoML.V1/Google.Cloud.AutoML.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BackupDR.V1",
+            "currentVersion": "2.1.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-13T18:26:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/backupdr/v1",
+                    "lastReleasedCommit": "8cd87061e43b6adf3f7d0b1d40d0f6192cc2ca74"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BackupDR.V1/Google.Cloud.BackupDR.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BareMetalSolution.V2",
+            "currentVersion": "1.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T06:54:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/baremetalsolution/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BareMetalSolution.V2/Google.Cloud.BareMetalSolution.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Batch.V1",
+            "currentVersion": "2.13.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-18T17:36:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/batch/v1",
+                    "lastReleasedCommit": "d383e2fe6661b29ea0def03c3900080ba953dd26"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Batch.V1/Google.Cloud.Batch.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Batch.V1Alpha",
+            "currentVersion": "1.0.0-alpha31",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-16T16:36:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/batch/v1alpha",
+                    "lastReleasedCommit": "2b46b7546bd801cf9bc9449843666c4b55fc574d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Batch.V1Alpha/Google.Cloud.Batch.V1Alpha"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BeyondCorp.AppConnections.V1",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:00:47Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/beyondcorp/appconnections/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BeyondCorp.AppConnections.V1/Google.Cloud.BeyondCorp.AppConnections.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BeyondCorp.AppConnectors.V1",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:56:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/beyondcorp/appconnectors/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BeyondCorp.AppConnectors.V1/Google.Cloud.BeyondCorp.AppConnectors.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BeyondCorp.AppGateways.V1",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:06:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/beyondcorp/appgateways/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BeyondCorp.AppGateways.V1/Google.Cloud.BeyondCorp.AppGateways.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BeyondCorp.ClientGateways.V1",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:00:40Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/beyondcorp/clientgateways/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BeyondCorp.ClientGateways.V1/Google.Cloud.BeyondCorp.ClientGateways.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.AnalyticsHub.V1",
+            "currentVersion": "1.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-07-08T16:34:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/analyticshub/v1",
+                    "lastReleasedCommit": "c23223d273469bc9c0f296856b47d22fa1dfe3d9"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.Connection.V1",
+            "currentVersion": "2.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T18:04:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/connection/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.Connection.V1/Google.Cloud.BigQuery.Connection.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.DataExchange.V1Beta1",
+            "currentVersion": "2.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T06:54:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/dataexchange/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.DataExchange.V1Beta1/Google.Cloud.BigQuery.DataExchange.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.DataPolicies.V1",
+            "currentVersion": "1.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:52:33Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/datapolicies/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.DataPolicies.V1/Google.Cloud.BigQuery.DataPolicies.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.DataPolicies.V1Beta1",
+            "currentVersion": "1.0.0-beta04",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T16:42:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/datapolicies/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.DataPolicies.V1Beta1/Google.Cloud.BigQuery.DataPolicies.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.DataTransfer.V1",
+            "currentVersion": "4.10.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-08T22:10:31Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/datatransfer/v1",
+                    "lastReleasedCommit": "463b5a6b06e20504fb44bfedff59ba05b42bf0b2"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.DataTransfer.V1/Google.Cloud.BigQuery.DataTransfer.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.Logging.V1",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-26T19:06:18Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/logging/v1",
+                    "lastReleasedCommit": "0adf469dcd7822bf5bc058a7b0217f5558a75643"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.Logging.V1/Google.Cloud.BigQuery.Logging.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.Migration.V2",
+            "currentVersion": "1.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-07-22T16:50:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/migration/v2",
+                    "lastReleasedCommit": "aa3a96ba03db3c8f3cc123d8507350ae873e7f8f"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.Migration.V2/Google.Cloud.BigQuery.Migration.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.Reservation.V1",
+            "currentVersion": "2.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-03T18:10:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/reservation/v1",
+                    "lastReleasedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.Reservation.V1/Google.Cloud.BigQuery.Reservation.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.V2",
+            "currentVersion": "3.11.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-03T17:58:23Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.V2/Google.Cloud.BigQuery.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BigQuery.Storage.V1",
+            "currentVersion": "3.17.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-14T16:10:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/bigquery/storage/v1",
+                    "lastReleasedCommit": "b49a983820806fc0d903370c0e75129fe7ae3c7b"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BigQuery.Storage.V1/Google.Cloud.BigQuery.Storage.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Bigtable.Admin.V2",
+            "currentVersion": "3.25.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:54:21Z",
+            "apis": [
+                {
+                    "apiId": "google/bigtable/admin/v2",
+                    "lastReleasedCommit": "b80f49d1bcb3b0f1de695d2d093ad3a43ac59f3b"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Bigtable.Admin.V2/Google.Cloud.Bigtable.Admin.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Bigtable.Common.V2",
+            "currentVersion": "3.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-26T19:14:17Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Bigtable.Common.V2/Google.Cloud.Bigtable.Common.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Bigtable.V2",
+            "currentVersion": "3.17.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:56:21Z",
+            "apis": [
+                {
+                    "apiId": "google/bigtable/v2",
+                    "lastReleasedCommit": "47d236a058fee1cf4cab357c852dc935d095bb69"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Bigtable.V2/Google.Cloud.Bigtable.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Billing.Budgets.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:52:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/billing/budgets/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Billing.Budgets.V1/Google.Cloud.Billing.Budgets.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Billing.Budgets.V1Beta1",
+            "currentVersion": "2.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T16:44:28Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/billing/budgets/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Billing.Budgets.V1Beta1/Google.Cloud.Billing.Budgets.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Billing.V1",
+            "currentVersion": "3.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-06T08:14:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/billing/v1",
+                    "lastReleasedCommit": "e5a39127db2d2339f7265be7175a3734385bd672"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Billing.V1/Google.Cloud.Billing.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BinaryAuthorization.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:56:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/binaryauthorization/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BinaryAuthorization.V1/Google.Cloud.BinaryAuthorization.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.BinaryAuthorization.V1Beta1",
+            "currentVersion": "2.0.0-beta08",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T16:46:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/binaryauthorization/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.BinaryAuthorization.V1Beta1/Google.Cloud.BinaryAuthorization.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.CertificateManager.V1",
+            "currentVersion": "2.8.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T06:56:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/certificatemanager/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.CertificateManager.V1/Google.Cloud.CertificateManager.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Channel.V1",
+            "currentVersion": "2.14.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-08T22:02:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/channel/v1",
+                    "lastReleasedCommit": "b6a27d13a2f0223051ef720e4e9d0d52323560e6"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Channel.V1/Google.Cloud.Channel.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.CloudBuild.V1",
+            "currentVersion": "2.15.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-18T17:34:27Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/cloudbuild/v1",
+                    "lastReleasedCommit": "da30f52583f070f676ed886ed9e33d84a646f74c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.CloudBuild.V1/Google.Cloud.CloudBuild.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.CloudBuild.V2",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:50:25Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/cloudbuild/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.CloudBuild.V2/Google.Cloud.CloudBuild.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.CloudControlsPartner.V1",
+            "currentVersion": "1.1.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-16T16:46:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/cloudcontrolspartner/v1",
+                    "lastReleasedCommit": "9ebde5402abfe4014e63f3a9bb45c206a2a66f32"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.CloudControlsPartner.V1/Google.Cloud.CloudControlsPartner.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.CloudControlsPartner.V1Beta",
+            "currentVersion": "1.0.0-beta04",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-27T18:02:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/cloudcontrolspartner/v1beta",
+                    "lastReleasedCommit": "4d8214803feb680a2dfa8ca4437b7ddfe64d146d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.CloudControlsPartner.V1Beta/Google.Cloud.CloudControlsPartner.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.CloudDms.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:54:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/clouddms/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.CloudDms.V1/Google.Cloud.CloudDms.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.CloudQuotas.V1",
+            "currentVersion": "1.1.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-11-18T19:30:44Z",
+            "apis": [
+                {
+                    "apiId": "google/api/cloudquotas/v1",
+                    "lastReleasedCommit": "453365efd71565dbecb05bbdc48513a7b3236d21"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.CloudQuotas.V1/Google.Cloud.CloudQuotas.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.CloudQuotas.V1Beta",
+            "currentVersion": "1.0.0-beta01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-08T16:38:21Z",
+            "apis": [
+                {
+                    "apiId": "google/api/cloudquotas/v1beta",
+                    "lastReleasedCommit": "2884323d6cc362b0b417e9bcc1c823243de63549"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.CloudQuotas.V1Beta/Google.Cloud.CloudQuotas.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Commerce.Consumer.Procurement.V1",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-08T22:06:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/commerce/consumer/procurement/v1",
+                    "lastReleasedCommit": "1f8352cf46df74d7db6fd544181655c590689b8c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Commerce.Consumer.Procurement.V1/Google.Cloud.Commerce.Consumer.Procurement.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Common",
+            "currentVersion": "2.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-26T20:38:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/common",
+                    "lastReleasedCommit": "4221b78ecddf8edf168ff2817ed6c14dd844ae2c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Common/Google.Cloud.Common"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Compute.V1",
+            "currentVersion": "3.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:50:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/compute/v1",
+                    "lastReleasedCommit": "9bf7eee7170c75870fb93320d8c30deddbed77fa"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Compute.V1/Google.Cloud.Compute.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ConfidentialComputing.V1",
+            "currentVersion": "1.8.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-25T19:18:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/confidentialcomputing/v1",
+                    "lastReleasedCommit": "2a8bb824f639c5e3b9567ea95a4e905d313fa6cf"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ConfidentialComputing.V1/Google.Cloud.ConfidentialComputing.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ConfidentialComputing.V1Alpha1",
+            "currentVersion": "1.0.0-alpha05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T17:32:19Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/confidentialcomputing/v1alpha1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ConfidentialComputing.V1Alpha1/Google.Cloud.ConfidentialComputing.V1Alpha1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Config.V1",
+            "currentVersion": "1.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-13T18:20:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/config/v1",
+                    "lastReleasedCommit": "29aea4190aba664659908ff5e381c830e4752502"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Config.V1/Google.Cloud.Config.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Connectors.V1",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:48:18Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/connectors/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Connectors.V1/Google.Cloud.Connectors.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ContactCenterInsights.V1",
+            "currentVersion": "2.19.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-06T17:50:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/contactcenterinsights/v1",
+                    "lastReleasedCommit": "5546362a78d82f8307eb1af4b2ac178a90cd9271"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ContactCenterInsights.V1/Google.Cloud.ContactCenterInsights.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Container.V1",
+            "currentVersion": "3.33.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-11-18T19:32:50Z",
+            "apis": [
+                {
+                    "apiId": "google/container/v1",
+                    "lastReleasedCommit": "48fb029710460cbc08f8916c9e2474c13b52d331"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Container.V1/Google.Cloud.Container.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DataCatalog.Lineage.V1",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:48:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/datacatalog/lineage/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.DataCatalog.Lineage.V1/Google.Cloud.DataCatalog.Lineage.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DataCatalog.V1",
+            "currentVersion": "2.15.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:50:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/datacatalog/v1",
+                    "lastReleasedCommit": "c18eb9fd055def47dcf2e26ffc06fdb02f9d15c7"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.DataCatalog.V1/Google.Cloud.DataCatalog.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DataFusion.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:54:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/datafusion/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.DataFusion.V1/Google.Cloud.DataFusion.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Dataflow.V1Beta3",
+            "currentVersion": "2.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T17:34:18Z",
+            "apis": [
+                {
+                    "apiId": "google/dataflow/v1beta3",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Dataflow.V1Beta3/Google.Cloud.Dataflow.V1Beta3"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Dataform.V1Beta1",
+            "currentVersion": "1.0.0-beta08",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-03T18:24:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/dataform/v1beta1",
+                    "lastReleasedCommit": "e7e526513dc435f0386358bd5354f3de6ced6380"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Dataform.V1Beta1/Google.Cloud.Dataform.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Dataplex.V1",
+            "currentVersion": "3.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:48:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/dataplex/v1",
+                    "lastReleasedCommit": "2415cfc65c4a5eb495117d5577ff5637a36436ed"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Dataplex.V1/Google.Cloud.Dataplex.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Dataproc.V1",
+            "currentVersion": "5.17.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-25T19:20:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/dataproc/v1",
+                    "lastReleasedCommit": "d4da473c44a15ff7ae6931edbd1c6a354b21d323"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Dataproc.V1/Google.Cloud.Dataproc.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Datastore.Admin.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-13T17:12:17Z",
+            "apis": [
+                {
+                    "apiId": "google/datastore/admin/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Datastore.Admin.V1/Google.Cloud.Datastore.Admin.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Datastore.V1",
+            "currentVersion": "4.15.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-12T16:44:46Z",
+            "apis": [
+                {
+                    "apiId": "google/datastore/v1",
+                    "lastReleasedCommit": "9415ba048aa587b1b2df2b96fc00aa009c831597"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Datastore.V1/Google.Cloud.Datastore.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Datastream.V1",
+            "currentVersion": "2.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-27T18:01:04Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/datastream/v1",
+                    "lastReleasedCommit": "5c2ccb6470e6a483f73c1be39b3d185e15d11808"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Datastream.V1Alpha1",
+            "currentVersion": "2.0.0-alpha05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-08T17:38:19Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/datastream/v1alpha1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Datastream.V1Alpha1/Google.Cloud.Datastream.V1Alpha1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Deploy.V1",
+            "currentVersion": "3.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-06T08:16:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/deploy/v1",
+                    "lastReleasedCommit": "99a5e296c891faa79784687422b9d555bcf54a3f"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Deploy.V1/Google.Cloud.Deploy.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DevTools.Common",
+            "currentVersion": "3.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-27T17:16:22Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.DevTools.Common/Google.Cloud.DevTools.Common"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Dialogflow.Cx.V3",
+            "currentVersion": "2.23.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-10T18:32:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/dialogflow/cx/v3",
+                    "lastReleasedCommit": "df58085901d8fb80c2c021e405923bb2351a6f29"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Dialogflow.Cx.V3/Google.Cloud.Dialogflow.Cx.V3"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Dialogflow.V2",
+            "currentVersion": "4.26.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-10T18:30:33Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/dialogflow/v2",
+                    "lastReleasedCommit": "c57048e5e01822cbac85d8d16660cd096454d00f"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Dialogflow.V2/Google.Cloud.Dialogflow.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Dialogflow.V2Beta1",
+            "currentVersion": "1.0.0-beta23",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-10T18:34:30Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/dialogflow/v2beta1",
+                    "lastReleasedCommit": "aee4464e15a44884a98ad737a007918a95764c93"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Dialogflow.V2Beta1/Google.Cloud.Dialogflow.V2Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DiscoveryEngine.V1",
+            "currentVersion": "1.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-29T17:02:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/discoveryengine/v1",
+                    "lastReleasedCommit": "537fd482f6bb8afb3a146d9b21673a8eb27958bd"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DiscoveryEngine.V1Beta",
+            "currentVersion": "1.0.0-beta18",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-30T16:52:28Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/discoveryengine/v1beta",
+                    "lastReleasedCommit": "e6b6ff9b7b3659641488e772355cdc78aac488ff"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.DiscoveryEngine.V1Beta/Google.Cloud.DiscoveryEngine.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Dlp.V2",
+            "currentVersion": "4.16.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-25T19:22:29Z",
+            "apis": [
+                {
+                    "apiId": "google/privacy/dlp/v2",
+                    "lastReleasedCommit": "40bad3ea0d48ecf250296ea7438035b8e45227dd"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Dlp.V2/Google.Cloud.Dlp.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DocumentAI.V1",
+            "currentVersion": "3.19.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-29T16:56:35Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/documentai/v1",
+                    "lastReleasedCommit": "76ca663d1df1cdd8e48f45af6e84212c551533ed"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.DocumentAI.V1/Google.Cloud.DocumentAI.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DocumentAI.V1Beta3",
+            "currentVersion": "2.0.0-beta23",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-22T17:56:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/documentai/v1beta3",
+                    "lastReleasedCommit": "211a72fa5cd90bfbfe2d86d4e8163eee23171687"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.DocumentAI.V1Beta3/Google.Cloud.DocumentAI.V1Beta3"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Domains.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:34:18Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/domains/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Domains.V1/Google.Cloud.Domains.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Domains.V1Beta1",
+            "currentVersion": "2.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:00:32Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/domains/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Domains.V1Beta1/Google.Cloud.Domains.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.EdgeNetwork.V1",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-07-08T16:38:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/edgenetwork/v1",
+                    "lastReleasedCommit": "16c01b440273ed685ae1d1ec7863d0f95f2a138d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.EdgeNetwork.V1/Google.Cloud.EdgeNetwork.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.EnterpriseKnowledgeGraph.V1",
+            "currentVersion": "1.0.0-beta04",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T05:00:31Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/enterpriseknowledgegraph/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.EnterpriseKnowledgeGraph.V1/Google.Cloud.EnterpriseKnowledgeGraph.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ErrorReporting.V1Beta1",
+            "currentVersion": "3.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T05:04:17Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/clouderrorreporting/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ErrorReporting.V1Beta1/Google.Cloud.ErrorReporting.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.EssentialContacts.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T06:56:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/essentialcontacts/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.EssentialContacts.V1/Google.Cloud.EssentialContacts.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Eventarc.Publishing.V1",
+            "currentVersion": "2.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-30T16:54:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/eventarc/publishing/v1",
+                    "lastReleasedCommit": "f7dd8db599b79c2e4b917c8296d90af68643a818"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Eventarc.Publishing.V1/Google.Cloud.Eventarc.Publishing.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Eventarc.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-29T16:54:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/eventarc/v1",
+                    "lastReleasedCommit": "8949e1719ba5956f0271a17cd5fa0cda900b9167"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Eventarc.V1/Google.Cloud.Eventarc.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Filestore.V1",
+            "currentVersion": "2.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-10T18:26:34Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/filestore/v1",
+                    "lastReleasedCommit": "607b7624f5d22202c601331465eb053833b4bf99"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Filestore.V1/Google.Cloud.Filestore.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Firestore.Admin.V1",
+            "currentVersion": "3.12.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-27T18:01:08Z",
+            "apis": [
+                {
+                    "apiId": "google/firestore/admin/v1",
+                    "lastReleasedCommit": "3776db131e34e42ec8d287203020cb4282166aa5"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Firestore.Admin.V1/Google.Cloud.Firestore.Admin.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Functions.V1",
+            "currentVersion": "2.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-08-13T16:06:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/functions/v1",
+                    "lastReleasedCommit": "7767c573e4fffa76310a876cc9d7995a74c37481"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Functions.V1/Google.Cloud.Functions.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Functions.V2",
+            "currentVersion": "1.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-08-13T16:04:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/functions/v2",
+                    "lastReleasedCommit": "8652e28bd0156553465918b9b7564420da79456e"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Functions.V2/Google.Cloud.Functions.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Functions.V2Beta",
+            "currentVersion": "1.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-08-13T16:06:11Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/functions/v2beta",
+                    "lastReleasedCommit": "182e5df1cc85f74cba78c5d974eb1f77092d57a6"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Functions.V2Beta/Google.Cloud.Functions.V2Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.GSuiteAddOns.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T06:58:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/gsuiteaddons/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.GSuiteAddOns.V1/Google.Cloud.GSuiteAddOns.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.GdcHardwareManagement.V1Alpha",
+            "currentVersion": "1.0.0-alpha04",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-11-18T16:18:48Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/gdchardwaremanagement/v1alpha",
+                    "lastReleasedCommit": "dee637f66f813b7f5dbdbdd8a1d1d23a2094144e"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.GdcHardwareManagement.V1Alpha/Google.Cloud.GdcHardwareManagement.V1Alpha"
+            ]
+        },
+        {
+            "id": "Google.Cloud.GkeBackup.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:06:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/gkebackup/v1",
+                    "lastReleasedCommit": "bcaed39fd1a805a6411a3992ea32dc1ba0ba7ec3"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.GkeBackup.V1/Google.Cloud.GkeBackup.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.GkeConnect.Gateway.V1",
+            "currentVersion": "1.0.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-05T19:00:31Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/gkeconnect/gateway/v1",
+                    "lastReleasedCommit": "de97a5f806a215960023d8d184a733260f8a9d3f"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.GkeConnect.Gateway.V1/Google.Cloud.GkeConnect.Gateway.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.GkeHub.V1Beta1",
+            "currentVersion": "2.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:26:19Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/gkehub/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.GkeHub.V1Beta1/Google.Cloud.GkeHub.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.GkeHub.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:10:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/gkehub/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.GkeHub.V1/Google.Cloud.GkeHub.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.GkeMultiCloud.V1",
+            "currentVersion": "2.8.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-06T16:12:52Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/gkemulticloud/v1",
+                    "lastReleasedCommit": "09b3c838b7758dc3fc1dbcc9dc6d3d5516beb544"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.GkeMultiCloud.V1/Google.Cloud.GkeMultiCloud.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Iam.Admin.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:00:44Z",
+            "apis": [
+                {
+                    "apiId": "google/iam/admin/v1",
+                    "lastReleasedCommit": "9c2348d2aa60700c15899c93e3b9615ab6ce1fcf"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Iam.Admin.V1/Google.Cloud.Iam.Admin.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Iam.Credentials.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:12:16Z",
+            "apis": [
+                {
+                    "apiId": "google/iam/credentials/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Iam.Credentials.V1/Google.Cloud.Iam.Credentials.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Iam.V1",
+            "currentVersion": "3.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-06T08:16:24Z",
+            "apis": [
+                {
+                    "apiId": "google/iam/v1",
+                    "lastReleasedCommit": "d675ec222c431e3346ba8aaf0027392fe8b3d90c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Iam.V1/Google.Cloud.Iam.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Iam.V2",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:02:33Z",
+            "apis": [
+                {
+                    "apiId": "google/iam/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Iam.V2/Google.Cloud.Iam.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Iap.V1",
+            "currentVersion": "2.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:00:36Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/iap/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Iap.V1/Google.Cloud.Iap.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Ids.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:08:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/ids/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Ids.V1/Google.Cloud.Ids.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Kms.Inventory.V1",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:10:30Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/kms/inventory/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Kms.Inventory.V1/Google.Cloud.Kms.Inventory.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Kms.V1",
+            "currentVersion": "3.16.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-25T19:18:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/kms/v1",
+                    "lastReleasedCommit": "0c860e055a00ff0b6553b7f1eb4e77829f00e12a"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Kms.V1/Google.Cloud.Kms.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Language.V1",
+            "currentVersion": "3.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:04:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/language/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Language.V1/Google.Cloud.Language.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Language.V2",
+            "currentVersion": "1.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-07-29T16:10:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/language/v2",
+                    "lastReleasedCommit": "ba245fa19c1e6f1f2a13055a437f0c815c061867"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Language.V2/Google.Cloud.Language.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.LifeSciences.V2Beta",
+            "currentVersion": "2.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T05:10:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/lifesciences/v2beta",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.LifeSciences.V2Beta/Google.Cloud.LifeSciences.V2Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Location",
+            "currentVersion": "2.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:16:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/location",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Location/Google.Cloud.Location"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Logging.Log4Net",
+            "currentVersion": "4.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-26T08:16:29Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Logging.Log4Net/Google.Cloud.Logging.Log4Net"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Logging.Console",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-03T18:14:27Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Logging.Console/Google.Cloud.Logging.Console"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Logging.NLog",
+            "currentVersion": "5.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-26T08:16:33Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Logging.NLog/Google.Cloud.Logging.NLog"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Logging.Type",
+            "currentVersion": "4.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-26T23:48:18Z",
+            "apis": [
+                {
+                    "apiId": "google/logging/type",
+                    "lastReleasedCommit": "736857e7a655eea72322e078b1988bd0d25aae0f"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Logging.Type/Google.Cloud.Logging.Type"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Logging.V2",
+            "currentVersion": "4.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:08:31Z",
+            "apis": [
+                {
+                    "apiId": "google/logging/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Logging.V2/Google.Cloud.Logging.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ManagedIdentities.V1",
+            "currentVersion": "3.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:06:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/managedidentities/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ManagedIdentities.V1/Google.Cloud.ManagedIdentities.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ManagedKafka.V1",
+            "currentVersion": "1.0.0-beta04",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:54:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/managedkafka/v1",
+                    "lastReleasedCommit": "8f7e301d346ba792a9bd282f8d62db7fad87cb8a"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ManagedKafka.V1/Google.Cloud.ManagedKafka.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.MediaTranslation.V1Beta1",
+            "currentVersion": "2.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T05:00:36Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/mediatranslation/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.MediaTranslation.V1Beta1/Google.Cloud.MediaTranslation.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Memcache.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:02:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/memcache/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Memcache.V1/Google.Cloud.Memcache.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Memcache.V1Beta2",
+            "currentVersion": "2.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:10:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/memcache/v1beta2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Memcache.V1Beta2/Google.Cloud.Memcache.V1Beta2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Memorystore.V1",
+            "currentVersion": "1.0.0-beta02",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-10T20:02:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/memorystore/v1",
+                    "lastReleasedCommit": "77857c7930c080d6d71179a1ee5610b347f413d0"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Memorystore.V1/Google.Cloud.Memorystore.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Memorystore.V1Beta",
+            "currentVersion": "1.0.0-beta02",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-10T20:01:05Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/memorystore/v1beta",
+                    "lastReleasedCommit": "f6c71177d0c954717065ab9d17e995590ce74b7c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Memorystore.V1Beta/Google.Cloud.Memorystore.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Metastore.V1",
+            "currentVersion": "2.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:10:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/metastore/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Metastore.V1/Google.Cloud.Metastore.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Metastore.V1Alpha",
+            "currentVersion": "2.0.0-alpha11",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:16:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/metastore/v1alpha",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Metastore.V1Alpha/Google.Cloud.Metastore.V1Alpha"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Metastore.V1Beta",
+            "currentVersion": "2.0.0-beta11",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:08:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/metastore/v1beta",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Metastore.V1Beta/Google.Cloud.Metastore.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.MigrationCenter.V1",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:06:28Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/migrationcenter/v1",
+                    "lastReleasedCommit": "3b84c01b5b0b38ef6bc1bf82ce43901be8c927e1"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.MigrationCenter.V1/Google.Cloud.MigrationCenter.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Monitoring.V3",
+            "currentVersion": "3.15.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-03T18:00:37Z",
+            "apis": [
+                {
+                    "apiId": "google/monitoring/v3",
+                    "lastReleasedCommit": "4d95834e9db8ee827f0e7846b175a3aeaf92f9ef"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Monitoring.V3/Google.Cloud.Monitoring.V3"
+            ]
+        },
+        {
+            "id": "Google.Cloud.NetApp.V1",
+            "currentVersion": "1.8.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-03T18:06:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/netapp/v1",
+                    "lastReleasedCommit": "d0cdaf8097981ede7d8132e768229e02416d9974"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.NetApp.V1/Google.Cloud.NetApp.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.NetworkConnectivity.V1",
+            "currentVersion": "2.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-06T08:08:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/networkconnectivity/v1",
+                    "lastReleasedCommit": "59254b411ac63bbb9bcd4a54cec10540ceaa5154"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.NetworkConnectivity.V1/Google.Cloud.NetworkConnectivity.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.NetworkConnectivity.V1Alpha1",
+            "currentVersion": "2.0.0-alpha04",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:06:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/networkconnectivity/v1alpha1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.NetworkConnectivity.V1Alpha1/Google.Cloud.NetworkConnectivity.V1Alpha1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.NetworkManagement.V1",
+            "currentVersion": "2.13.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-13T18:18:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/networkmanagement/v1",
+                    "lastReleasedCommit": "d5cc1cd738a66bb7104162bcb35ebd539c658415"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.NetworkManagement.V1/Google.Cloud.NetworkManagement.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.NetworkSecurity.V1Beta1",
+            "currentVersion": "2.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:22:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/networksecurity/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.NetworkSecurity.V1Beta1/Google.Cloud.NetworkSecurity.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.NetworkServices.V1",
+            "currentVersion": "1.0.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-05T18:56:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/networkservices/v1",
+                    "lastReleasedCommit": "6f0843548b06bfd3368da47ac6c40e77ea6c6109"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.NetworkServices.V1/Google.Cloud.NetworkServices.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Notebooks.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:10:35Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/notebooks/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Notebooks.V1/Google.Cloud.Notebooks.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Notebooks.V1Beta1",
+            "currentVersion": "2.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:12:30Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/notebooks/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Notebooks.V1Beta1/Google.Cloud.Notebooks.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Notebooks.V2",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:08:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/notebooks/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Notebooks.V2/Google.Cloud.Notebooks.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Optimization.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:14:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/optimization/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Optimization.V1/Google.Cloud.Optimization.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.OracleDatabase.V1",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:46:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/oracledatabase/v1",
+                    "lastReleasedCommit": "e4515ba9ef4f8d75d6d38de3a2b3fe6654705b26"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.OracleDatabase.V1/Google.Cloud.OracleDatabase.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Orchestration.Airflow.Service.V1",
+            "currentVersion": "2.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-16T16:34:31Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/orchestration/airflow/service/v1",
+                    "lastReleasedCommit": "0f44538daf93e648e4fe5529acf8219cef3a0a39"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Orchestration.Airflow.Service.V1/Google.Cloud.Orchestration.Airflow.Service.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.OrgPolicy.V1",
+            "currentVersion": "3.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-27T04:50:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/orgpolicy/v1",
+                    "lastReleasedCommit": "4d27ae79c480f0de8e88aae02c53ee7fb9fc03f5"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.OrgPolicy.V1/Google.Cloud.OrgPolicy.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.OrgPolicy.V2",
+            "currentVersion": "2.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-26T08:20:28Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/orgpolicy/v2",
+                    "lastReleasedCommit": "0a87fe7bcf2c106bff0316384366b98cd2b2e2db"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.OrgPolicy.V2/Google.Cloud.OrgPolicy.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.OsConfig.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:18:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/osconfig/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.OsConfig.V1/Google.Cloud.OsConfig.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.OsConfig.V1Alpha",
+            "currentVersion": "2.0.0-alpha06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:04:20Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/osconfig/v1alpha",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.OsConfig.V1Alpha/Google.Cloud.OsConfig.V1Alpha"
+            ]
+        },
+        {
+            "id": "Google.Cloud.OsLogin.Common",
+            "currentVersion": "3.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-27T04:42:19Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/oslogin/common",
+                    "lastReleasedCommit": "00234dcb9882c4dfc5cb0a7eacafc6ff1b1eb221"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.OsLogin.Common/Google.Cloud.OsLogin.Common"
+            ]
+        },
+        {
+            "id": "Google.Cloud.OsLogin.V1",
+            "currentVersion": "3.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:18:19Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/oslogin/v1",
+                    "lastReleasedCommit": "0842829df747446019e4dcf53030ef84bfc0ad21"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.OsLogin.V1/Google.Cloud.OsLogin.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.OsLogin.V1Beta",
+            "currentVersion": "3.0.0-beta09",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:28:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/oslogin/v1beta",
+                    "lastReleasedCommit": "51c176bef48b9a88694e496c070bcfc965c70ad2"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.OsLogin.V1Beta/Google.Cloud.OsLogin.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Parallelstore.V1",
+            "currentVersion": "1.1.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-18T17:36:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/parallelstore/v1",
+                    "lastReleasedCommit": "a003cab30e2a263e16e9252256041f8934f40e2c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Parallelstore.V1/Google.Cloud.Parallelstore.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Parallelstore.V1Beta",
+            "currentVersion": "1.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-06T08:08:32Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/parallelstore/v1beta",
+                    "lastReleasedCommit": "9ea2c56cb70d70f10fd2bef310ac9febe8d42d30"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Parallelstore.V1Beta/Google.Cloud.Parallelstore.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ParameterManager.V1",
+            "currentVersion": "1.0.0-beta01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-21T18:04:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/parametermanager/v1",
+                    "lastReleasedCommit": "a1b92fac8aa318ea01ee6f0c0d0cc937e35ed7b3"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ParameterManager.V1/Google.Cloud.ParameterManager.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.PhishingProtection.V1Beta1",
+            "currentVersion": "2.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T05:04:18Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/phishingprotection/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.PhishingProtection.V1Beta1/Google.Cloud.PhishingProtection.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.PolicySimulator.V1",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:10:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/policysimulator/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.PolicySimulator.V1/Google.Cloud.PolicySimulator.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.PolicyTroubleshooter.Iam.V3",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:40:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/policytroubleshooter/iam/v3",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.PolicyTroubleshooter.Iam.V3/Google.Cloud.PolicyTroubleshooter.Iam.V3"
+            ]
+        },
+        {
+            "id": "Google.Cloud.PolicyTroubleshooter.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:32:46Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/policytroubleshooter/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.PolicyTroubleshooter.V1/Google.Cloud.PolicyTroubleshooter.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.PrivateCatalog.V1Beta1",
+            "currentVersion": "2.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T05:02:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/privatecatalog/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.PrivateCatalog.V1Beta1/Google.Cloud.PrivateCatalog.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.PrivilegedAccessManager.V1",
+            "currentVersion": "1.0.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-05T18:54:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/privilegedaccessmanager/v1",
+                    "lastReleasedCommit": "aa3dd2bc6cbb44fa75443ddf44e73b6d36a90766"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.PrivilegedAccessManager.V1/Google.Cloud.PrivilegedAccessManager.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Profiler.V2",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:50:22Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/cloudprofiler/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Profiler.V2/Google.Cloud.Profiler.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.PubSub.V1",
+            "currentVersion": "3.23.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-14T07:56:22Z",
+            "apis": [
+                {
+                    "apiId": "google/pubsub/v1",
+                    "lastReleasedCommit": "263055cc1fc36dc2828e50eb7a92d75b1e0e4af5"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.PubSub.V1/Google.Cloud.PubSub.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.RapidMigrationAssessment.V1",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:38:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/rapidmigrationassessment/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.RapidMigrationAssessment.V1/Google.Cloud.RapidMigrationAssessment.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.RecaptchaEnterprise.V1",
+            "currentVersion": "2.18.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:46:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/recaptchaenterprise/v1",
+                    "lastReleasedCommit": "5b8c54e53d8d05f5a75e3f21ac5518b23878b696"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.RecaptchaEnterprise.V1/Google.Cloud.RecaptchaEnterprise.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.RecaptchaEnterprise.V1Beta1",
+            "currentVersion": "2.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-04-29T17:16:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/recaptchaenterprise/v1beta1",
+                    "lastReleasedCommit": "0179dcc4d2b4d7376e7f0292b15c72aab3100dd6"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.RecaptchaEnterprise.V1Beta1/Google.Cloud.RecaptchaEnterprise.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.RecommendationEngine.V1Beta1",
+            "currentVersion": "2.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:16:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/recommendationengine/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.RecommendationEngine.V1Beta1/Google.Cloud.RecommendationEngine.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Recommender.V1",
+            "currentVersion": "3.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:46:30Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/recommender/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Recommender.V1/Google.Cloud.Recommender.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Redis.Cluster.V1",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-27T17:56:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/redis/cluster/v1",
+                    "lastReleasedCommit": "d4c6826b966464a3e7e272bb44d7ed563b5abe81"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Redis.Cluster.V1/Google.Cloud.Redis.Cluster.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Redis.V1",
+            "currentVersion": "3.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:48:30Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/redis/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Redis.V1/Google.Cloud.Redis.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Redis.V1Beta1",
+            "currentVersion": "3.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:32:51Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/redis/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Redis.V1Beta1/Google.Cloud.Redis.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ResourceManager.V3",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:40:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/resourcemanager/v3",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ResourceManager.V3/Google.Cloud.ResourceManager.V3"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Retail.V2",
+            "currentVersion": "2.12.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-14T16:08:28Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/retail/v2",
+                    "lastReleasedCommit": "d01eb4689472766df6822cdfcdb4412bfb4c2789"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Retail.V2/Google.Cloud.Retail.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Run.V2",
+            "currentVersion": "2.13.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-10T19:48:49Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/run/v2",
+                    "lastReleasedCommit": "3d194928f8427e6d33156f9193af053fe74f996d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Run.V2/Google.Cloud.Run.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Scheduler.V1",
+            "currentVersion": "3.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:36:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/scheduler/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Scheduler.V1/Google.Cloud.Scheduler.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.SecretManager.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:52:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/secretmanager/v1",
+                    "lastReleasedCommit": "034570432b14b429c5f597701132b6d9ceb553a2"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.SecretManager.V1/Google.Cloud.SecretManager.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.SecretManager.V1Beta2",
+            "currentVersion": "1.0.0-beta03",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T16:34:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/secretmanager/v1beta2",
+                    "lastReleasedCommit": "13edbc1d295bc1bcedd9b561eb7c83db36ca0f7e"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.SecretManager.V1Beta2/Google.Cloud.SecretManager.V1Beta2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.SecretManager.V1Beta1",
+            "currentVersion": "3.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:58:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/secrets/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.SecretManager.V1Beta1/Google.Cloud.SecretManager.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Security.PrivateCA.V1",
+            "currentVersion": "3.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:04:32Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/security/privateca/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Security.PrivateCA.V1/Google.Cloud.Security.PrivateCA.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Security.PublicCA.V1",
+            "currentVersion": "1.0.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-05T18:52:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/security/publicca/v1",
+                    "lastReleasedCommit": "3cba4738844f57da2272c4e23db3f5e9bf30bb81"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Security.PublicCA.V1/Google.Cloud.Security.PublicCA.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Security.PublicCA.V1Beta1",
+            "currentVersion": "1.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T16:34:18Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/security/publicca/v1beta1",
+                    "lastReleasedCommit": "25a1a57957d9e4bf431897d280b2569b26dc9165"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Security.PublicCA.V1Beta1/Google.Cloud.Security.PublicCA.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.SecurityCenter.Settings.V1Beta1",
+            "currentVersion": "2.0.0-beta04",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T16:34:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/securitycenter/settings/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.SecurityCenter.Settings.V1Beta1/Google.Cloud.SecurityCenter.Settings.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.SecurityCenter.V1",
+            "currentVersion": "3.24.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-08-13T16:06:24Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/securitycenter/v1",
+                    "lastReleasedCommit": "ae593946b7cd10df5535b910b7a2ce2b64ff4098"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.SecurityCenter.V1/Google.Cloud.SecurityCenter.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.SecurityCenter.V1P1Beta1",
+            "currentVersion": "3.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T16:36:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/securitycenter/v1p1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.SecurityCenter.V1P1Beta1/Google.Cloud.SecurityCenter.V1P1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.SecurityCenter.V2",
+            "currentVersion": "1.1.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-02-18T17:32:55Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/securitycenter/v2",
+                    "lastReleasedCommit": "f2ce5f2be39bdedbc0b576812873f521230bf3d7"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.SecurityCenter.V2/Google.Cloud.SecurityCenter.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.SecurityCenterManagement.V1",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-10-30T16:54:28Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/securitycentermanagement/v1",
+                    "lastReleasedCommit": "0841f8250e08699194cf15bf491257a313d60503"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.SecurityCenterManagement.V1/Google.Cloud.SecurityCenterManagement.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ServiceControl.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:42:34Z",
+            "apis": [
+                {
+                    "apiId": "google/api/servicecontrol/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ServiceControl.V1/Google.Cloud.ServiceControl.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ServiceDirectory.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-06T08:24:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/servicedirectory/v1",
+                    "lastReleasedCommit": "0f3c90f83afe5c01a8ca2a4e3ae10df82818ae48"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ServiceDirectory.V1/Google.Cloud.ServiceDirectory.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ServiceDirectory.V1Beta1",
+            "currentVersion": "2.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T16:34:35Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/servicedirectory/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ServiceDirectory.V1Beta1/Google.Cloud.ServiceDirectory.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ServiceHealth.V1",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-06T08:04:29Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/servicehealth/v1",
+                    "lastReleasedCommit": "1e6bc362db25a51da39dd2d6b7d47664879ecf41"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ServiceHealth.V1/Google.Cloud.ServiceHealth.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ServiceManagement.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:34:23Z",
+            "apis": [
+                {
+                    "apiId": "google/api/servicemanagement/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ServiceManagement.V1/Google.Cloud.ServiceManagement.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.ServiceUsage.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:46:20Z",
+            "apis": [
+                {
+                    "apiId": "google/api/serviceusage/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.ServiceUsage.V1/Google.Cloud.ServiceUsage.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Shell.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:48:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/shell/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Shell.V1/Google.Cloud.Shell.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Speech.V1",
+            "currentVersion": "3.8.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:38:23Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/speech/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Speech.V1/Google.Cloud.Speech.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Speech.V1P1Beta1",
+            "currentVersion": "3.0.0-beta08",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T08:06:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/speech/v1p1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Speech.V1P1Beta1/Google.Cloud.Speech.V1P1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Speech.V2",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-06T18:06:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/speech/v2",
+                    "lastReleasedCommit": "bf2a7ca1d46894df9ebccf5ad6338cbe9e21d9a8"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Speech.V2/Google.Cloud.Speech.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Storage.Control.V2",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:42:32Z",
+            "apis": [
+                {
+                    "apiId": "google/storage/control/v2",
+                    "lastReleasedCommit": "1f01eefb40000d70b0c58314709af1d4f8222cc0"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Storage.Control.V2/Google.Cloud.Storage.Control.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Storage.V1",
+            "currentVersion": "4.11.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-10T18:24:32Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Storage.V1/Google.Cloud.Storage.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.StorageInsights.V1",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:42:30Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/storageinsights/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.StorageInsights.V1/Google.Cloud.StorageInsights.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.StorageTransfer.V1",
+            "currentVersion": "2.8.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-06T18:04:26Z",
+            "apis": [
+                {
+                    "apiId": "google/storagetransfer/v1",
+                    "lastReleasedCommit": "67495ab130490fec112841715649b86a7d335e6a"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.StorageTransfer.V1/Google.Cloud.StorageTransfer.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Support.V2",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:42:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/support/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Support.V2/Google.Cloud.Support.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Talent.V4",
+            "currentVersion": "2.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-06T18:10:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/talent/v4",
+                    "lastReleasedCommit": "c72d7385435589176aa6e44563fcfbc795b9a476"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Talent.V4/Google.Cloud.Talent.V4"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Talent.V4Beta1",
+            "currentVersion": "3.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-06T18:04:33Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/talent/v4beta1",
+                    "lastReleasedCommit": "528ea46081bccba0dcb89abd79362d3decfa37a9"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Talent.V4Beta1/Google.Cloud.Talent.V4Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Tasks.V2",
+            "currentVersion": "3.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:42:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/tasks/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Tasks.V2/Google.Cloud.Tasks.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Tasks.V2Beta3",
+            "currentVersion": "3.0.0-beta07",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:10:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/tasks/v2beta3",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Tasks.V2Beta3/Google.Cloud.Tasks.V2Beta3"
+            ]
+        },
+        {
+            "id": "Google.Cloud.TelcoAutomation.V1",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:44:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/telcoautomation/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.TelcoAutomation.V1/Google.Cloud.TelcoAutomation.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.TextToSpeech.V1",
+            "currentVersion": "3.10.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-13T18:16:33Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/texttospeech/v1",
+                    "lastReleasedCommit": "2dee81b474957f04a0c277f6bf91cfeb13f12f55"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.TextToSpeech.V1/Google.Cloud.TextToSpeech.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.TextToSpeech.V1Beta1",
+            "currentVersion": "2.0.0-beta12",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-06T18:06:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/texttospeech/v1beta1",
+                    "lastReleasedCommit": "d985436b77cfd0231bb170014e4eadc19392d3ff"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.TextToSpeech.V1Beta1/Google.Cloud.TextToSpeech.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Tpu.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-13T18:12:27Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/tpu/v1",
+                    "lastReleasedCommit": "c3556b45dc35a145e04b5692bc72e01a4f58a6b2"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Tpu.V1/Google.Cloud.Tpu.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Trace.V1",
+            "currentVersion": "3.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:50:18Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/cloudtrace/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Trace.V1/Google.Cloud.Trace.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Trace.V2",
+            "currentVersion": "3.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:46:26Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/cloudtrace/v2",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Trace.V2/Google.Cloud.Trace.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Translate.V3",
+            "currentVersion": "3.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-11-18T19:28:31Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/translate/v3",
+                    "lastReleasedCommit": "1f2e5aab4f95b9bd38dd1ac8c7486657f93c1975"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Translate.V3/Google.Cloud.Translate.V3"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Translation.V2",
+            "currentVersion": "3.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-26T19:47:02Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Translation.V2/Google.Cloud.Translation.V2"
+            ]
+        },
+        {
+            "id": "Google.Cloud.VMMigration.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:50:26Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/vmmigration/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.VMMigration.V1/Google.Cloud.VMMigration.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Video.LiveStream.V1",
+            "currentVersion": "1.8.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-07-22T16:40:30Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/video/livestream/v1",
+                    "lastReleasedCommit": "19577edb4d439db98d2fb1f6f48f2e1b29fba099"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Video.LiveStream.V1/Google.Cloud.Video.LiveStream.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Video.Stitcher.V1",
+            "currentVersion": "3.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T07:30:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/video/stitcher/v1",
+                    "lastReleasedCommit": "30717c0b0c9966906880703208a4c820411565c4"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Video.Stitcher.V1/Google.Cloud.Video.Stitcher.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Video.Transcoder.V1",
+            "currentVersion": "2.9.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:48:18Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/video/transcoder/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Video.Transcoder.V1/Google.Cloud.Video.Transcoder.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.VideoIntelligence.V1",
+            "currentVersion": "3.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:48:34Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/videointelligence/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.VideoIntelligence.V1/Google.Cloud.VideoIntelligence.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Vision.V1",
+            "currentVersion": "3.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:52:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/vision/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Vision.V1/Google.Cloud.Vision.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.VmwareEngine.V1",
+            "currentVersion": "1.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-07-22T16:36:28Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/vmwareengine/v1",
+                    "lastReleasedCommit": "db2ac7a5afc0d859b102f2334abda6761a0ab62d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.VmwareEngine.V1/Google.Cloud.VmwareEngine.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.VpcAccess.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:52:30Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/vpcaccess/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.VpcAccess.V1/Google.Cloud.VpcAccess.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.WebRisk.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T07:42:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/webrisk/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.WebRisk.V1/Google.Cloud.WebRisk.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.WebRisk.V1Beta1",
+            "currentVersion": "3.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:08:21Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/webrisk/v1beta1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.WebRisk.V1Beta1/Google.Cloud.WebRisk.V1Beta1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.WebSecurityScanner.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T15:40:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/websecurityscanner/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.WebSecurityScanner.V1/Google.Cloud.WebSecurityScanner.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Workflows.Common.V1",
+            "currentVersion": "2.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-26T19:52:25Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Workflows.Common.V1/Google.Cloud.Workflows.Common.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Workflows.Common.V1Beta",
+            "currentVersion": "2.0.0-beta04",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-26T19:52:48Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Workflows.Common.V1Beta/Google.Cloud.Workflows.Common.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Workflows.Executions.V1",
+            "currentVersion": "2.6.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T15:42:17Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/workflows/executions/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Workflows.Executions.V1/Google.Cloud.Workflows.Executions.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Workflows.Executions.V1Beta",
+            "currentVersion": "2.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:58:16Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/workflows/executions/v1beta",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Workflows.Executions.V1Beta/Google.Cloud.Workflows.Executions.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Workflows.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T15:40:22Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/workflows/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Workflows.V1/Google.Cloud.Workflows.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Workflows.V1Beta",
+            "currentVersion": "2.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:08:25Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/workflows/v1beta",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Workflows.V1Beta/Google.Cloud.Workflows.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Workstations.V1",
+            "currentVersion": "1.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T15:38:18Z",
+            "apis": [
+                {
+                    "apiId": "google/cloud/workstations/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Workstations.V1/Google.Cloud.Workstations.V1"
+            ]
+        },
+        {
+            "id": "Google.Geo.Type",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-27T08:28:16Z",
+            "apis": [
+                {
+                    "apiId": "google/geo/type",
+                    "lastReleasedCommit": "f07100f48e0dc2303e65f1f51ad8e520f5942f0e"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Geo.Type/Google.Geo.Type"
+            ]
+        },
+        {
+            "id": "Google.Identity.AccessContextManager.Type",
+            "currentVersion": "2.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-27T08:20:20Z",
+            "apis": [
+                {
+                    "apiId": "google/identity/accesscontextmanager/type",
+                    "lastReleasedCommit": "4221b78ecddf8edf168ff2817ed6c14dd844ae2c"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Identity.AccessContextManager.Type/Google.Identity.AccessContextManager.Type"
+            ]
+        },
+        {
+            "id": "Google.Identity.AccessContextManager.V1",
+            "currentVersion": "2.5.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T15:42:21Z",
+            "apis": [
+                {
+                    "apiId": "google/identity/accesscontextmanager/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Identity.AccessContextManager.V1/Google.Identity.AccessContextManager.V1"
+            ]
+        },
+        {
+            "id": "Google.LongRunning",
+            "currentVersion": "3.3.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T15:44:16Z",
+            "apis": [
+                {
+                    "apiId": "google/longrunning",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.LongRunning/Google.LongRunning"
+            ]
+        },
+        {
+            "id": "Google.Maps.AddressValidation.V1",
+            "currentVersion": "1.4.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T15:40:26Z",
+            "apis": [
+                {
+                    "apiId": "google/maps/addressvalidation/v1",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Maps.AddressValidation.V1/Google.Maps.AddressValidation.V1"
+            ]
+        },
+        {
+            "id": "Google.Maps.AreaInsights.V1",
+            "currentVersion": "1.0.0-beta01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-10T07:45:39Z",
+            "apis": [
+                {
+                    "apiId": "google/maps/areainsights/v1",
+                    "lastReleasedCommit": "be61427b6ce8ebd86bd04bc46f1cee4ae036f1ad"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Maps.AreaInsights.V1/Google.Maps.AreaInsights.V1"
+            ]
+        },
+        {
+            "id": "Google.Maps.FleetEngine.Delivery.V1",
+            "currentVersion": "2.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-03T18:10:29Z",
+            "apis": [
+                {
+                    "apiId": "google/maps/fleetengine/delivery/v1",
+                    "lastReleasedCommit": "fcd9d6582e9dd821553c4bd93a6d418e87f8a9fe"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Maps.FleetEngine.Delivery.V1/Google.Maps.FleetEngine.Delivery.V1"
+            ]
+        },
+        {
+            "id": "Google.Maps.FleetEngine.V1",
+            "currentVersion": "2.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-03T18:12:25Z",
+            "apis": [
+                {
+                    "apiId": "google/maps/fleetengine/v1",
+                    "lastReleasedCommit": "fcd9d6582e9dd821553c4bd93a6d418e87f8a9fe"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Maps.FleetEngine.V1/Google.Maps.FleetEngine.V1"
+            ]
+        },
+        {
+            "id": "Google.Maps.MapsPlatformDatasets.V1",
+            "currentVersion": "1.0.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-14T08:28:27Z",
+            "apis": [
+                {
+                    "apiId": "google/maps/mapsplatformdatasets/v1",
+                    "lastReleasedCommit": "ce39e78569ce4425237781756a6de6b2a628f555"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Maps.MapsPlatformDatasets.V1/Google.Maps.MapsPlatformDatasets.V1"
+            ]
+        },
+        {
+            "id": "Google.Maps.Places.V1",
+            "currentVersion": "1.0.0-beta14",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:52:28Z",
+            "apis": [
+                {
+                    "apiId": "google/maps/places/v1",
+                    "lastReleasedCommit": "b3d8e7d376b864efeef6e6ee15805763dfa2b47d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Maps.Places.V1/Google.Maps.Places.V1"
+            ]
+        },
+        {
+            "id": "Google.Maps.RouteOptimization.V1",
+            "currentVersion": "1.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-09-26T08:24:24Z",
+            "apis": [
+                {
+                    "apiId": "google/maps/routeoptimization/v1",
+                    "lastReleasedCommit": "534e49c0ca0b9297f4ede6f119a0db054b35dd1e"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Maps.RouteOptimization.V1/Google.Maps.RouteOptimization.V1"
+            ]
+        },
+        {
+            "id": "Google.Maps.Routing.V2",
+            "currentVersion": "1.0.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-14T08:30:25Z",
+            "apis": [
+                {
+                    "apiId": "google/maps/routing/v2",
+                    "lastReleasedCommit": "a3211f3342219aad1b310ec1739476586384473a"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Maps.Routing.V2/Google.Maps.Routing.V2"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Css.V1",
+            "currentVersion": "1.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-01-06T18:08:27Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/css/v1",
+                    "lastReleasedCommit": "892e72fb31d9c063f9b992bfd923730094233ed0"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Css.V1/Google.Shopping.Css.V1"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Accounts.V1Beta",
+            "currentVersion": "1.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:44:28Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/accounts/v1beta",
+                    "lastReleasedCommit": "fa2198128e162a80ff7ea56d46ef0b254af4980b"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Accounts.V1Beta/Google.Shopping.Merchant.Accounts.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Conversions.V1Beta",
+            "currentVersion": "1.0.0-beta02",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:20:20Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/conversions/v1beta",
+                    "lastReleasedCommit": "09848563c56a70af398ee6a1877f36cc65cb41a2"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Conversions.V1Beta/Google.Shopping.Merchant.Conversions.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.DataSources.V1Beta",
+            "currentVersion": "1.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:42:36Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/datasources/v1beta",
+                    "lastReleasedCommit": "b2fc92c85219ec4283b877abdfef688269d26e8a"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.DataSources.V1Beta/Google.Shopping.Merchant.DataSources.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Inventories.V1Beta",
+            "currentVersion": "1.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:14:17Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/inventories/v1beta",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Inventories.V1Beta/Google.Shopping.Merchant.Inventories.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Lfp.V1Beta",
+            "currentVersion": "1.0.0-beta02",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:12:25Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/lfp/v1beta",
+                    "lastReleasedCommit": "09848563c56a70af398ee6a1877f36cc65cb41a2"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Lfp.V1Beta/Google.Shopping.Merchant.Lfp.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Notifications.V1Beta",
+            "currentVersion": "1.0.0-beta02",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:18:17Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/notifications/v1beta",
+                    "lastReleasedCommit": "09848563c56a70af398ee6a1877f36cc65cb41a2"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Notifications.V1Beta/Google.Shopping.Merchant.Notifications.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Products.V1Beta",
+            "currentVersion": "1.0.0-beta03",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-17T18:40:29Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/products/v1beta",
+                    "lastReleasedCommit": "bc7f715d7f58afe381fbc244a8bcde7f0afa11ed"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Products.V1Beta/Google.Shopping.Merchant.Products.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Promotions.V1Beta",
+            "currentVersion": "1.0.0-beta01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-13T06:26:18Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/promotions/v1beta",
+                    "lastReleasedCommit": "b9b8f6333c413e1e22307d10dff012e89d6bf75a"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Promotions.V1Beta/Google.Shopping.Merchant.Promotions.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Quota.V1Beta",
+            "currentVersion": "1.0.0-beta03",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-14T15:36:19Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/quota/v1beta",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Quota.V1Beta/Google.Shopping.Merchant.Quota.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Reports.V1Beta",
+            "currentVersion": "1.0.0-beta03",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-06-05T06:04:17Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/reports/v1beta",
+                    "lastReleasedCommit": "57514fbcb92c243fc478fdd540e5bf40bd91bf64"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Reports.V1Beta/Google.Shopping.Merchant.Reports.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Merchant.Reviews.V1Beta",
+            "currentVersion": "1.0.0-beta01",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-12-10T16:27:17Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/merchant/reviews/v1beta",
+                    "lastReleasedCommit": "f3c8df7ee195f0053c5dd36c0e5abd4511fe960b"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Merchant.Reviews.V1Beta/Google.Shopping.Merchant.Reviews.V1Beta"
+            ]
+        },
+        {
+            "id": "Google.Shopping.Type",
+            "currentVersion": "1.0.0-beta06",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-05-09T17:14:21Z",
+            "apis": [
+                {
+                    "apiId": "google/shopping/type",
+                    "lastReleasedCommit": "3597f7db2191c00b100400991ef96e52d62f5841"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Shopping.Type/Google.Shopping.Type"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Spanner",
+            "currentVersion": "5.0.0-beta05",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-11-07T07:44:20Z",
+            "apis": [
+                {
+                    "apiId": "google/spanner/admin/database/v1",
+                    "lastReleasedCommit": "96facece981f227c5d54133845fc519f73900b8e"
+                },
+                {
+                    "apiId": "google/spanner/admin/instance/v1",
+                    "lastReleasedCommit": "b11e6b0741fc333f7d558447f2efda76db44243d"
+                },
+                {
+                    "apiId": "google/spanner/v1",
+                    "lastReleasedCommit": "2b6b93bc89ecf122e1bd230e6d07312b0185cbe5"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Spanner.Admin.Database.V1/Google.Cloud.Spanner.Admin.Database.V1",
+                "apis/Google.Cloud.Spanner.Admin.Instance.V1/Google.Cloud.Spanner.Admin.Instance.V1",
+                "apis/Google.Cloud.Spanner.Data/Google.Cloud.Spanner.Data",
+                "apis/Google.Cloud.Spanner.Common.V1/Google.Cloud.Spanner.Common.V1",
+                "apis/Google.Cloud.Spanner.V1/Google.Cloud.Spanner.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Diagnostics",
+            "currentVersion": "5.2.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-03-05T19:58:15Z",
+            "apis": [],
+            "sourcePaths": [
+                "apis/Google.Cloud.Diagnostics.AspNetCore3/Google.Cloud.Diagnostics.AspNetCore3",
+                "apis/Google.Cloud.Diagnostics.Common/Google.Cloud.Diagnostics.Common"
+            ]
+        },
+        {
+            "id": "Google.Cloud.DevTools.ContainerAnalysis",
+            "currentVersion": "3.7.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2024-11-18T19:38:17Z",
+            "apis": [
+                {
+                    "apiId": "google/devtools/containeranalysis/v1",
+                    "lastReleasedCommit": "8ea348f641af88cd703023f72a857497c206a229"
+                },
+                {
+                    "apiId": "grafeas/v1",
+                    "lastReleasedCommit": "ad5c47728cac14fc75d152b2736c4872637e7a6d"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.DevTools.ContainerAnalysis.V1/Google.Cloud.DevTools.ContainerAnalysis.V1",
+                "apis/Grafeas.V1/Grafeas.V1"
+            ]
+        },
+        {
+            "id": "Google.Cloud.Firestore",
+            "currentVersion": "3.10.0",
+            "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
+            "releaseTimestamp": "2025-03-12T16:42:22Z",
+            "apis": [
+                {
+                    "apiId": "google/firestore/v1",
+                    "lastReleasedCommit": "fd510f8e0f12ef5e2f77be2dd4b6316d39952a37"
+                }
+            ],
+            "sourcePaths": [
+                "apis/Google.Cloud.Firestore/Google.Cloud.Firestore",
+                "apis/Google.Cloud.Firestore.V1/Google.Cloud.Firestore.V1"
+            ]
+        }
+    ],
+    "common_library_source_paths": [
+        "Directory.Packages.props"
+    ]
 }

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -343,7 +343,7 @@
         },
         {
             "id": "google/cloud/compute/v1",
-            "lastGeneratedCommit": "2753fe1683a42442aa7a4b778c416c886a647fe6",
+            "lastGeneratedCommit": "633014022be4611d3dab03c5f44da62450ee563a",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
         },
         {
@@ -2413,7 +2413,7 @@
         },
         {
             "id": "Google.Cloud.Compute.V1",
-            "currentVersion": "3.6.0",
+            "currentVersion": "3.7.0",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2025-03-17T18:50:24Z",
             "apis": [

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -83,7 +83,7 @@
         },
         {
             "id": "google/cloud/alloydb/v1beta",
-            "lastGeneratedCommit": "6155d42e99f45ebf53100d492852be1561916137",
+            "lastGeneratedCommit": "602d65c092a5310d93b80e965fe9539b6ae679b3",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC"
         },
         {
@@ -1585,7 +1585,7 @@
         },
         {
             "id": "Google.Cloud.AlloyDb.V1Beta",
-            "currentVersion": "1.0.0-beta09",
+            "currentVersion": "1.0.0-beta10",
             "automationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseTimestamp": "2024-11-18T19:34:39Z",
             "apis": [


### PR DESCRIPTION
There were errors found in creating this release PR:Google.Cloud.Spanner: unable to retrieve commits since previous release tag Google.Cloud.Spanner-5.0.0-beta05
Google.Cloud.Spanner: unable to retrieve commits since previous release tag Google.Cloud.Spanner-5.0.0-beta05
Google.Cloud.Spanner: unable to retrieve commits since previous release tag Google.Cloud.Spanner-5.0.0-beta05
Google.Cloud.Spanner: unable to retrieve commits since previous release tag Google.Cloud.Spanner-5.0.0-beta05
Google.Cloud.Spanner: unable to retrieve commits since previous release tag Google.Cloud.Spanner-5.0.0-beta05
Google.Cloud.Diagnostics: unable to retrieve commits since previous release tag Google.Cloud.Diagnostics-5.2.0
Google.Cloud.Diagnostics: unable to retrieve commits since previous release tag Google.Cloud.Diagnostics-5.2.0
Google.Cloud.DevTools.ContainerAnalysis: unable to retrieve commits since previous release tag Google.Cloud.DevTools.ContainerAnalysis-3.7.0
Google.Cloud.DevTools.ContainerAnalysis: unable to retrieve commits since previous release tag Google.Cloud.DevTools.ContainerAnalysis-3.7.0
Release library: Google.Ads.AdManager.V1 version 1.0.0-beta02
Release library: Google.Cloud.AlloyDb.V1Beta version 1.0.0-beta10
Release library: Google.Cloud.AIPlatform.V1 version 3.24.0
Release library: Google.Cloud.Compute.V1 version 3.7.0
Release library: Google.Cloud.DocumentAI.V1Beta3 version 2.0.0-beta24
Release library: Google.Cloud.ManagedKafka.V1 version 1.0.0-beta05
Release library: Google.Cloud.Workflows.V1 version 2.6.0
Release library: Google.Shopping.Merchant.Products.V1Beta version 1.0.0-beta04

