### PR TITLE
chore(main): release

### DIFF
--- a/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.csproj
+++ b/apis/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1/Google.Cloud.AppHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0</Version>
+    <Version>1.1.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the App Hub API, which simplifies the process of building, running, and managing applications on Google Cloud.</Description>

--- a/apis/Google.Cloud.AppHub.V1/docs/history.md
+++ b/apis/Google.Cloud.AppHub.V1/docs/history.md
@@ -1,5 +1,15 @@
 # Version history
 
+## Version 1.1.0, released 2025-03-28
+
+### New features
+
+- add enum `Type.GLOBAL`
+
+### Documentation improvements
+
+- misc comment updates, formatting
+
 ## Version 1.0.0, released 2024-12-05
 
 No API surface changes; just dependency updates and promotion to GA.

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1/Google.Cloud.BigQuery.AnalyticsHub.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.7.0</Version>
+    <Version>1.8.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the BigQuery Analytics Hub, which allows users to exchange data and analytics assets securely and efficiently.</Description>

--- a/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
+++ b/apis/Google.Cloud.BigQuery.AnalyticsHub.V1/docs/history.md
@@ -1,5 +1,11 @@
 # Version history
 
+## Version 1.8.0, released 2025-03-28
+
+### New features
+
+- Support new feature Sharing Cloud Pubsub Streams via AH (GA) and Subscriber Email logging feature
+
 ## Version 1.7.0, released 2024-07-08
 
 ### New features

--- a/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
+++ b/apis/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1/Google.Cloud.Datastream.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>2.9.0</Version>
+    <Version>2.10.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Cloud Datastream API (v1), which allows you to synchronize data across heterogeneous databases and applications reliably, and with minimal latency and downtime.</Description>

--- a/apis/Google.Cloud.Datastream.V1/docs/history.md
+++ b/apis/Google.Cloud.Datastream.V1/docs/history.md
@@ -1,5 +1,22 @@
 # Version history
 
+## Version 2.10.0, released 2025-03-28
+
+### New features
+
+- A new field `secret_manager_stored_password` is added to multiple messages
+- A new messages related to `SalesforceProfile` are added
+- A new message `BlmtConfig` is added
+- A new field `blmt_config` is added to message `.google.cloud.datastream.v1.BigQueryDestinationConfig`
+- A new field `satisfies_pzs` is added to multiple messages.
+- A new field `satisfies_pzi` is added to multiple messages.
+- A new message `MysqlGtidPosition` is added
+- A new field `mysql_gtid_position` is added to message `.google.cloud.datastream.v1.CdcStrategy`
+
+### Documentation improvements
+
+- documentation improvements and changes for multiple fields
+
 ## Version 2.9.0, released 2025-01-27
 
 ### New features

--- a/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1/Google.Cloud.DiscoveryEngine.V1.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.6.0</Version>
+    <Version>1.7.0</Version>
     <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Description>Recommended Google client library to access the Google Discovery Engine API (v1). Discovery Engine powers high-quality content recommendations on your digital properties for Discovery for Media.</Description>

--- a/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
+++ b/apis/Google.Cloud.DiscoveryEngine.V1/docs/history.md
@@ -1,5 +1,34 @@
 # Version history
 
+## Version 1.7.0, released 2025-03-28
+
+### New features
+
+- move serving config update API to GA
+- add time_zone in user info
+- add stream answer API
+- support query rephraser model for answer API
+- support end user spec for answer API
+- support grounding and safety rating for answer API
+- support relevance threshold in search
+- support boosting for blended search
+- support auto mode in search as your type
+- support model scores in search
+- support search highlighting
+- support enterprise web retrieval source for grounding
+- support images in web search grounding
+- add sitemap APIs
+- add interpolation boost action and promotion action
+- allow FHIR import to use latest predefined schema
+- allow unstructured data import to force refresh all content
+- support conversion user event
+- support panel aware user event
+
+### Documentation improvements
+
+- keep the API doc up-to-date with recent changes
+- keep the API doc up-to-date with recent changes
+
 ## Version 1.6.0, released 2024-10-29
 
 ### New features

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -1943,7 +1943,7 @@
     },
     {
       "id": "Google.Cloud.Datastream.V1",
-      "version": "2.9.0",
+      "version": "2.10.0",
       "type": "grpc",
       "productName": "DataStream",
       "productUrl": "https://cloud.google.com/datastream/docs",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -2213,7 +2213,7 @@
     },
     {
       "id": "Google.Cloud.DiscoveryEngine.V1",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "type": "grpc",
       "productName": "Discovery Engine",
       "productUrl": "https://cloud.google.com/discovery-engine/docs",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -558,7 +558,7 @@
     },
     {
       "id": "Google.Cloud.AppHub.V1",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "type": "grpc",
       "productName": "App Hub",
       "productUrl": "https://cloud.google.com/app-hub/docs/overview",

--- a/generator-input/apis.json
+++ b/generator-input/apis.json
@@ -923,7 +923,7 @@
     },
     {
       "id": "Google.Cloud.BigQuery.AnalyticsHub.V1",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "type": "grpc",
       "productName": "Analytics Hub",
       "productUrl": "https://cloud.google.com/analytics-hub",

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1229,11 +1229,12 @@
         },
         {
             "id": "Google.Cloud.Datastream.V1",
-            "currentVersion": "2.9.0",
+            "currentVersion": "2.10.0",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseTimestamp": "2025-01-27T18:01:04Z",
+            "releaseTimestamp": "2025-03-28T18:54:40.558617128Z",
             "lastGeneratedCommit": "18f8cb5b581d073222006396175cd0a360a72adf",
+            "lastReleasedCommit": "18f8cb5b581d073222006396175cd0a360a72adf",
             "apiPaths": [
                 "google/cloud/datastream/v1"
             ],

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -592,11 +592,12 @@
         },
         {
             "id": "Google.Cloud.BigQuery.AnalyticsHub.V1",
-            "currentVersion": "1.7.0",
+            "currentVersion": "1.8.0",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseTimestamp": "2024-07-08T16:34:20Z",
+            "releaseTimestamp": "2025-03-28T18:53:31.479060774Z",
             "lastGeneratedCommit": "b64f36a8c04a977e6d6ad3924ee37a3a94b36212",
+            "lastReleasedCommit": "b64f36a8c04a977e6d6ad3924ee37a3a94b36212",
             "apiPaths": [
                 "google/cloud/bigquery/analyticshub/v1"
             ],

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -1336,11 +1336,12 @@
         },
         {
             "id": "Google.Cloud.DiscoveryEngine.V1",
-            "currentVersion": "1.6.0",
+            "currentVersion": "1.7.0",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseTimestamp": "2024-10-29T17:02:20Z",
+            "releaseTimestamp": "2025-03-28T18:55:33.407396763Z",
             "lastGeneratedCommit": "ebc5e127e8854dd107de7d7a0abee815a5404a68",
+            "lastReleasedCommit": "ebc5e127e8854dd107de7d7a0abee815a5404a68",
             "apiPaths": [
                 "google/cloud/discoveryengine/v1"
             ],

--- a/generator-input/pipeline-state.json
+++ b/generator-input/pipeline-state.json
@@ -367,11 +367,12 @@
         },
         {
             "id": "Google.Cloud.AppHub.V1",
-            "currentVersion": "1.0.0",
+            "currentVersion": "1.1.0",
             "generationAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
             "releaseAutomationLevel": "AUTOMATION_LEVEL_AUTOMATIC",
-            "releaseTimestamp": "2024-12-05T19:02:21Z",
+            "releaseTimestamp": "2025-03-28T18:52:20.017296882Z",
             "lastGeneratedCommit": "f4a56c163276d5b42d3849a57cd7c92b5152a697",
+            "lastReleasedCommit": "f4a56c163276d5b42d3849a57cd7c92b5152a697",
             "apiPaths": [
                 "google/cloud/apphub/v1"
             ],


### PR DESCRIPTION
Release Errors:
==================
:Google.Cloud.AlloyDb.V1Beta: unable to retrieve commits since previous release tag Google.Cloud.AlloyDb.V1Beta-1.0.0-beta10
Google.Cloud.AIPlatform.V1Beta1: unable to retrieve commits since previous release tag Google.Cloud.AIPlatform.V1Beta1-1.0.0-beta23
Google.Cloud.AIPlatform.V1: unable to retrieve commits since previous release tag Google.Cloud.AIPlatform.V1-3.24.0
Google.Cloud.Compute.V1: unable to retrieve commits since previous release tag Google.Cloud.Compute.V1-3.7.0
Google.Cloud.DeveloperConnect.V1: unable to retrieve commits since previous release tag Google.Cloud.DeveloperConnect.V1-
Google.Cloud.Dialogflow.V2: unable to retrieve commits since previous release tag Google.Cloud.Dialogflow.V2-4.26.0
Google.Cloud.Dlp.V2: unable to retrieve commits since previous release tag Google.Cloud.Dlp.V2-4.17.0
Google.Cloud.DocumentAI.V1Beta3: unable to retrieve commits since previous release tag Google.Cloud.DocumentAI.V1Beta3-2.0.0-beta24
Google.Cloud.ManagedKafka.V1: unable to retrieve commits since previous release tag Google.Cloud.ManagedKafka.V1-1.0.0-beta05
Google.Cloud.NetworkConnectivity.V1: unable to retrieve commits since previous release tag Google.Cloud.NetworkConnectivity.V1-2.10.0
Google.Cloud.ParameterManager.V1: unable to retrieve commits since previous release tag Google.Cloud.ParameterManager.V1-1.0.0-beta02
Google.Cloud.SecureSourceManager.V1: unable to retrieve commits since previous release tag Google.Cloud.SecureSourceManager.V1-
Google.Cloud.Storage.V2: unable to retrieve commits since previous release tag Google.Cloud.Storage.V2-
Google.Cloud.VisionAI.V1: unable to retrieve commits since previous release tag Google.Cloud.VisionAI.V1-
Google.Cloud.Workflows.V1: unable to retrieve commits since previous release tag Google.Cloud.Workflows.V1-2.6.0
Google.Cloud.Spanner: unable to retrieve commits since previous release tag Google.Cloud.Spanner-5.0.0-beta05
Google.Cloud.Diagnostics: unable to retrieve commits since previous release tag Google.Cloud.Diagnostics-5.2.0
Google.Cloud.DevTools.ContainerAnalysis: unable to retrieve commits since previous release tag Google.Cloud.DevTools.ContainerAnalysis-3.7.0

==================
Releases Included:
==================
Release library: Google.Cloud.AppHub.V1 version 1.1.0
Release library: Google.Cloud.BigQuery.AnalyticsHub.V1 version 1.8.0
Release library: Google.Cloud.Datastream.V1 version 2.10.0
Release library: Google.Cloud.DiscoveryEngine.V1 version 1.7.0

